### PR TITLE
feat: android support for ue 5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ DerivedDataCache/*
 .idea/
 
 node_modules/
+
+.DS_Store
+Content/.DS_Store

--- a/Source/Immutable/Private/Immutable/ImmutableSubsystem.cpp
+++ b/Source/Immutable/Private/Immutable/ImmutableSubsystem.cpp
@@ -22,7 +22,14 @@ void UImmutableSubsystem::Initialize(FSubsystemCollectionBase& Collection)
     IMTBL_LOG_FUNCSIG
     Super::Initialize(Collection);
 
-	ViewportCreatedHandle = UGameViewportClient::OnViewportCreated().AddUObject(this, &UImmutableSubsystem::OnViewportCreated);
+#if PLATFORM_ANDROID
+    // Enable DOM storage so we can use localStorage in the Android webview
+    GConfig->SetBool(TEXT("/Script/AndroidRuntimeSettings.AndroidRuntimeSettings"), TEXT("bEnableDomStorage"), true, GEngineIni);
+
+    EngineInitCompleteHandle = FCoreDelegates::OnFEngineLoopInitComplete.AddUObject(this, &UImmutableSubsystem::OnViewportCreated);
+#else
+    ViewportCreatedHandle = UGameViewportClient::OnViewportCreated().AddUObject(this, &UImmutableSubsystem::OnViewportCreated);
+#endif
     WorldTickHandle = FWorldDelegates::OnWorldTickStart.AddUObject(this, &UImmutableSubsystem::WorldTickStart);
 }
 

--- a/Source/Immutable/Private/Immutable/ImtblBrowserUserWidget.cpp
+++ b/Source/Immutable/Private/Immutable/ImtblBrowserUserWidget.cpp
@@ -41,8 +41,15 @@ TSharedRef<SWidget> UImtblBrowserUserWidget::RebuildWidget()
 			ScaleBox->AddChild(Browser);
             if (UCanvasPanelSlot* RootWidgetSlot = Cast<UCanvasPanelSlot>(ScaleBox->Slot))
 			{
+#if PLATFORM_ANDROID
+                // Android webview needs to be at least 1px to 1px big to work
+                // but it can be off screen
+                RootWidgetSlot->SetAnchors(FAnchors(0, 0, 0, 0));
+                RootWidgetSlot->SetOffsets(FMargin(-1, -1, 1, 1));
+#else
 				RootWidgetSlot->SetAnchors(FAnchors(0, 0, 1, 1));
 				RootWidgetSlot->SetOffsets(DefaultOffsets);
+#endif
 			}
             if (UScaleBoxSlot* ScaleBoxSlot = Cast<UScaleBoxSlot>(Browser->Slot))
 			{
@@ -64,6 +71,7 @@ void UImtblBrowserUserWidget::BeginDestroy()
 
 void UImtblBrowserUserWidget::RemoveFromParent()
 {
+#if !PLATFORM_ANDROID
     // This is all that is needed to persist the widget state outside throughout level/world changes.
 	// Super::RemoveFromParent();
 
@@ -71,12 +79,17 @@ void UImtblBrowserUserWidget::RemoveFromParent()
 	{
 		CurrentParent->RemoveChild(this);
 	}
+#endif
 }
 
 
 void UImtblBrowserUserWidget::OnWidgetRebuilt()
 {
+#if PLATFORM_ANDROID
+    // Android webview needs to be visible to work
+#else
     SetVisibility(ESlateVisibility::Collapsed);
+#endif
     Super::OnWidgetRebuilt();
 }
 

--- a/Source/Immutable/Private/Immutable/ImtblBrowserWidget.cpp
+++ b/Source/Immutable/Private/Immutable/ImtblBrowserWidget.cpp
@@ -146,6 +146,9 @@ TSharedRef<SWidget> UImtblBrowserWidget::RebuildWidget()
 			.ShowControls(false)
 			.SupportsTransparency(bSupportsTransparency)
 	        .ShowInitialThrobber(bShowInitialThrobber)
+#if PLATFORM_ANDROID
+	        .OnLoadCompleted(BIND_UOBJECT_DELEGATE(FSimpleDelegate, HandleOnLoadCompleted))
+#endif
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 	        .OnConsoleMessage(BIND_UOBJECT_DELEGATE(FOnConsoleMessageDelegate, HandleOnConsoleMessage))
 #endif
@@ -163,6 +166,17 @@ TSharedRef<SWidget> UImtblBrowserWidget::RebuildWidget()
 #endif
 	}
 }
+
+
+#if PLATFORM_ANDROID
+void UImtblBrowserWidget::HandleOnLoadCompleted()
+{
+	if (WebBrowserWidget->GetUrl() == "file://immutable/index.html")
+	{
+		JSConnector->SetAndroidBridgeReady();
+	}
+}
+#endif
 
 
 void UImtblBrowserWidget::OnWidgetRebuilt()

--- a/Source/Immutable/Private/Immutable/ImtblBrowserWidget.h
+++ b/Source/Immutable/Private/Immutable/ImtblBrowserWidget.h
@@ -51,6 +51,10 @@ private:
     bool BindUObject(const FString& Name, UObject* Object, bool bIsPermanent = true) const;
     // Bind the JSConnector to the browser window
     void BindConnector();
+
+#if PLATFORM_ANDROID
+    void HandleOnLoadCompleted();
+#endif
     
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
     void HandleOnConsoleMessage(const FString& Message, const FString& Source, int32 Line, EWebBrowserConsoleLogSeverity Severity);

--- a/Source/Immutable/Private/Immutable/ImtblJSConnector.cpp
+++ b/Source/Immutable/Private/Immutable/ImtblJSConnector.cpp
@@ -142,4 +142,12 @@ void UImtblJSConnector::SendToGame(FString Message)
 }
 
 
-
+#if PLATFORM_ANDROID
+void UImtblJSConnector::SetAndroidBridgeReady()
+{
+        IMTBL_LOG_FUNCSIG
+        bIsBridgeReady = true;
+        OnBridgeReady.Broadcast();
+        OnBridgeReady.Clear();
+}
+#endif

--- a/Source/Immutable/Private/Immutable/ImtblJSConnector.h
+++ b/Source/Immutable/Private/Immutable/ImtblJSConnector.h
@@ -51,6 +51,10 @@ public:
     // Bind the func to be called for executing JS. Typically by the BrowserWidget (UE5) or Blui for UE4
     FOnExecuteJsDelegate ExecuteJs;
 
+#if PLATFORM_ANDROID
+    void SetAndroidBridgeReady();
+#endif
+
 protected:
 
     // Call a JavaScript function in the connected browser

--- a/Source/Immutable/Public/Immutable/ImmutableSubsystem.h
+++ b/Source/Immutable/Public/Immutable/ImmutableSubsystem.h
@@ -59,6 +59,9 @@ private:
 
     FDelegateHandle WorldTickHandle;
     FDelegateHandle ViewportCreatedHandle;
+#if PLATFORM_ANDROID
+    FDelegateHandle EngineInitCompleteHandle;
+#endif
 	
     void SetupGameBridge();
 	void OnBridgeReady();


### PR DESCRIPTION
Get SDK to run on Android devices. This is for UE 5.2 only.

Changes required:
- Set up the game bridge after the game engine init loop completes instead of when the viewport is created
- Instead of waiting for a response for 'init' to come back from the bridge to signal that the browser is ready, use the page load completed event instead. This is because there is some delay in binding all `window.ue` functions/values (including `window.ue.jsconnector`).
- Android webview cannot be collapsed but needs to be at least 1px x 1 px. However, the Android webview is offscreen, so it doesn't overlap with the game.
- To persist the Android webview across levels, the user widget cannot be removed from the parent
- Enable DOM storage for Android webview so we can use localStorage