### PR TITLE
feat: ios support for ue 5.2

### DIFF
--- a/Source/Immutable/Private/Immutable/ImmutableSubsystem.cpp
+++ b/Source/Immutable/Private/Immutable/ImmutableSubsystem.cpp
@@ -25,7 +25,9 @@ void UImmutableSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 #if PLATFORM_ANDROID
     // Enable DOM storage so we can use localStorage in the Android webview
     GConfig->SetBool(TEXT("/Script/AndroidRuntimeSettings.AndroidRuntimeSettings"), TEXT("bEnableDomStorage"), true, GEngineIni);
+#endif
 
+#if PLATFORM_ANDROID | PLATFORM_IOS
     EngineInitCompleteHandle = FCoreDelegates::OnFEngineLoopInitComplete.AddUObject(this, &UImmutableSubsystem::OnViewportCreated);
 #else
     ViewportCreatedHandle = UGameViewportClient::OnViewportCreated().AddUObject(this, &UImmutableSubsystem::OnViewportCreated);
@@ -40,8 +42,11 @@ void UImmutableSubsystem::Deinitialize()
     BrowserWidget = nullptr;
     ImtblBlui = nullptr;
     Passport = nullptr;
-
+#if PLATFORM_ANDROID | PLATFORM_IOS
+    UGameViewportClient::OnViewportCreated().Remove(EngineInitCompleteHandle);
+#else
     UGameViewportClient::OnViewportCreated().Remove(ViewportCreatedHandle);
+#endif
     FWorldDelegates::OnWorldTickStart.Remove(WorldTickHandle);
     
     Super::Deinitialize();

--- a/Source/Immutable/Private/Immutable/ImtblBrowserUserWidget.cpp
+++ b/Source/Immutable/Private/Immutable/ImtblBrowserUserWidget.cpp
@@ -41,7 +41,7 @@ TSharedRef<SWidget> UImtblBrowserUserWidget::RebuildWidget()
 			ScaleBox->AddChild(Browser);
             if (UCanvasPanelSlot* RootWidgetSlot = Cast<UCanvasPanelSlot>(ScaleBox->Slot))
 			{
-#if PLATFORM_ANDROID
+#if PLATFORM_ANDROID | PLATFORM_IOS
                 // Android webview needs to be at least 1px to 1px big to work
                 // but it can be off screen
                 RootWidgetSlot->SetAnchors(FAnchors(0, 0, 0, 0));
@@ -85,8 +85,8 @@ void UImtblBrowserUserWidget::RemoveFromParent()
 
 void UImtblBrowserUserWidget::OnWidgetRebuilt()
 {
-#if PLATFORM_ANDROID
-    // Android webview needs to be visible to work
+#if PLATFORM_ANDROID | PLATFORM_IOS
+    // Mobile webview needs to be visible to work
 #else
     SetVisibility(ESlateVisibility::Collapsed);
 #endif

--- a/Source/Immutable/Private/Immutable/ImtblBrowserWidget.cpp
+++ b/Source/Immutable/Private/Immutable/ImtblBrowserWidget.cpp
@@ -15,21 +15,21 @@
 
 UImtblBrowserWidget::UImtblBrowserWidget()
 {
-	IMTBL_LOG_FUNCSIG
+    IMTBL_LOG_FUNCSIG
 
-	JSConnector = NewObject<UImtblJSConnector>(this, "JSConnector");
-	JSConnector->ExecuteJs = UImtblJSConnector::FOnExecuteJsDelegate::CreateUObject(this, &UImtblBrowserWidget::ExecuteJS);
+    JSConnector = NewObject<UImtblJSConnector>(this, "JSConnector");
+    JSConnector->ExecuteJs = UImtblJSConnector::FOnExecuteJsDelegate::CreateUObject(this, &UImtblBrowserWidget::ExecuteJS);
 
-	// WebBrowserWidget->LoadString("<html><head><title>Test</title></head><body><h1>Test</h1></body></html>", TEXT("http://www.google.com"));
-	// InitialURL = TEXT("http://www.google.com");
-	// InitialURL = TEXT("chrome://version");
-	// IPluginManager& PluginManager = IPluginManager::Get();
-	// if (const TSharedPtr<IPlugin> Plugin = PluginManager.FindPlugin("Immutable"))
-	// {
-	//     InitialURL = FString::Printf(TEXT("%s%s"), TEXT("file:///"), *FPaths::ConvertRelativePathToFull(FPaths::Combine(Plugin->GetContentDir(), TEXT("index.html"))));
-	//     IMTBL_LOG("Loading initial url: %s", *InitialURL)
-	// }
-	InitialURL = TEXT("about:blank");
+    // WebBrowserWidget->LoadString("<html><head><title>Test</title></head><body><h1>Test</h1></body></html>", TEXT("http://www.google.com"));
+    // InitialURL = TEXT("http://www.google.com");
+    // InitialURL = TEXT("chrome://version");
+    // IPluginManager& PluginManager = IPluginManager::Get();
+    // if (const TSharedPtr<IPlugin> Plugin = PluginManager.FindPlugin("Immutable"))
+    // {
+    //     InitialURL = FString::Printf(TEXT("%s%s"), TEXT("file:///"), *FPaths::ConvertRelativePathToFull(FPaths::Combine(Plugin->GetContentDir(), TEXT("index.html"))));
+    //     IMTBL_LOG("Loading initial url: %s", *InitialURL)
+    // }
+    InitialURL = TEXT("about:blank");
 }
 
 void UImtblBrowserWidget::BindConnector()
@@ -41,10 +41,10 @@ void UImtblBrowserWidget::BindConnector()
 
     if (JSConnector)
     {
-	    if (BindUObject(UImtblJSConnector::JSObjectName(), JSConnector))
-	    {
-		    JSConnector->Init(IsPageLoaded());
-	    }
+        if (BindUObject(UImtblJSConnector::JSObjectName(), JSConnector))
+        {
+            JSConnector->Init(IsPageLoaded());
+        }
     }
 }
 
@@ -60,7 +60,7 @@ bool UImtblBrowserWidget::IsPageLoaded() const
 #if USING_BUNDLED_CEF
     return WebBrowserWidget.IsValid() && WebBrowserWidget->IsLoaded();
 #endif
-	return false;
+    return false;
 }
 
 
@@ -78,7 +78,7 @@ void UImtblBrowserWidget::ExecuteJS(const FString& ScriptText) const
 void UImtblBrowserWidget::SetBrowserContent()
 {
 #if USING_BUNDLED_CEF
-	FSoftObjectPath AssetRef(TEXT("/Script/Immutable.ImtblSDKResource'/Immutable/PackagedResources/index.index'"));
+    FSoftObjectPath AssetRef(TEXT("/Script/Immutable.ImtblSDKResource'/Immutable/PackagedResources/index.index'"));
     if (UObject* LoadedAsset = AssetRef.TryLoad())
     {
         if (auto Resource = Cast<UImtblSDKResource>(LoadedAsset))
@@ -89,10 +89,10 @@ void UImtblBrowserWidget::SetBrowserContent()
                 return;
             }
 
-        	const FString IndexHtml = FString("<!doctype html><html lang='en'><head><meta charset='utf-8'><title>GameSDK Bridge</title><script>")
-        								+ Resource->Js
-        								+ FString("</script></head><body><h1>Bridge Running</h1></body></html>");
-        	
+            const FString IndexHtml = FString("<!doctype html><html lang='en'><head><meta charset='utf-8'><title>GameSDK Bridge</title><script>")
+                                        + Resource->Js
+                                        + FString("</script></head><body><h1>Bridge Running</h1></body></html>");
+            
             // IMTBL_LOG("Loaded resource: %s", *Resource->GetName())
             WebBrowserWidget->LoadString(IndexHtml, TEXT("file://immutable/index.html"));
             // WebBrowserWidget->LoadURL(FString::Printf(TEXT("%s%s"), TEXT("file:///"), *FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectContentDir(), TEXT("html"), TEXT("index.html")))));
@@ -119,62 +119,68 @@ bool UImtblBrowserWidget::BindUObject(const FString& Name, UObject* Object, cons
 
 void UImtblBrowserWidget::ReleaseSlateResources(bool bReleaseChildren)
 {
-	Super::ReleaseSlateResources(bReleaseChildren);
+    Super::ReleaseSlateResources(bReleaseChildren);
 #if USING_BUNDLED_CEF
-	WebBrowserWidget.Reset();
+    WebBrowserWidget.Reset();
 #endif
 }
 
 
 TSharedRef<SWidget> UImtblBrowserWidget::RebuildWidget()
 {
-	if (IsDesignTime())
-	{
-		return SNew(SBox)
-			.HAlign(HAlign_Center)
-			.VAlign(VAlign_Center)
-			[
-				SNew(STextBlock)
-				.Text(NSLOCTEXT("Immutable", "Immutable Web Browser", "Immutable Web Browser"))
-			];
-	}
-	else
-	{
+    if (IsDesignTime())
+    {
+        return SNew(SBox)
+            .HAlign(HAlign_Center)
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock)
+                .Text(NSLOCTEXT("Immutable", "Immutable Web Browser", "Immutable Web Browser"))
+            ];
+    }
+    else
+    {
 #if USING_BUNDLED_CEF
-		WebBrowserWidget = SNew(SWebBrowser)
-			.InitialURL(InitialURL)
-			.ShowControls(false)
-			.SupportsTransparency(bSupportsTransparency)
-	        .ShowInitialThrobber(bShowInitialThrobber)
-#if PLATFORM_ANDROID
-	        .OnLoadCompleted(BIND_UOBJECT_DELEGATE(FSimpleDelegate, HandleOnLoadCompleted))
+        WebBrowserWidget = SNew(SWebBrowser)
+            .InitialURL(InitialURL)
+            .ShowControls(false)
+            .SupportsTransparency(bSupportsTransparency)
+            .ShowInitialThrobber(bShowInitialThrobber)
+#if PLATFORM_ANDROID | PLATFORM_IOS
+            .OnLoadCompleted(BIND_UOBJECT_DELEGATE(FSimpleDelegate, HandleOnLoadCompleted))
 #endif
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
-	        .OnConsoleMessage(BIND_UOBJECT_DELEGATE(FOnConsoleMessageDelegate, HandleOnConsoleMessage))
+            .OnConsoleMessage(BIND_UOBJECT_DELEGATE(FOnConsoleMessageDelegate, HandleOnConsoleMessage))
 #endif
-	    ;
+        ;
 
-		return WebBrowserWidget.ToSharedRef();
+        return WebBrowserWidget.ToSharedRef();
 #else
-		return SNew(SBox)
-			.HAlign(HAlign_Center)
-			.VAlign(VAlign_Center)
-			[
-				SNew(STextBlock)
-				.Text(NSLOCTEXT("Immutable", "Immutable Web Browser", "Immutable Web Browser"))
-			];
+        return SNew(SBox)
+            .HAlign(HAlign_Center)
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock)
+                .Text(NSLOCTEXT("Immutable", "Immutable Web Browser", "Immutable Web Browser"))
+            ];
 #endif
-	}
+    }
 }
 
 
-#if PLATFORM_ANDROID
+#if PLATFORM_ANDROID | PLATFORM_IOS
 void UImtblBrowserWidget::HandleOnLoadCompleted()
 {
-	if (WebBrowserWidget->GetUrl() == "file://immutable/index.html")
-	{
-		JSConnector->SetAndroidBridgeReady();
-	}
+#if PLATFORM_ANDROID
+    FString indexUrl =  "file://immutable/index.html";
+#else
+    FString indexUrl =  "file:///index.html";
+#endif
+    
+    if (WebBrowserWidget->GetUrl() == indexUrl)
+    {
+        JSConnector->SetMobileBridgeReady();
+    }
 }
 #endif
 
@@ -192,7 +198,7 @@ void UImtblBrowserWidget::HandleOnConsoleMessage(const FString& Message, const F
 {
     // TODO: add severity to log and callback
     IMTBL_LOG("Browser console message: %s, Source: %s, Line: %d", *Message, *Source, Line);
-	OnConsoleMessage.Broadcast(Message, Source, Line);
+    OnConsoleMessage.Broadcast(Message, Source, Line);
 }
 #endif
 

--- a/Source/Immutable/Private/Immutable/ImtblBrowserWidget.h
+++ b/Source/Immutable/Private/Immutable/ImtblBrowserWidget.h
@@ -52,7 +52,7 @@ private:
     // Bind the JSConnector to the browser window
     void BindConnector();
 
-#if PLATFORM_ANDROID
+#if PLATFORM_ANDROID | PLATFORM_IOS
     void HandleOnLoadCompleted();
 #endif
     

--- a/Source/Immutable/Private/Immutable/ImtblJSConnector.cpp
+++ b/Source/Immutable/Private/Immutable/ImtblJSConnector.cpp
@@ -142,8 +142,8 @@ void UImtblJSConnector::SendToGame(FString Message)
 }
 
 
-#if PLATFORM_ANDROID
-void UImtblJSConnector::SetAndroidBridgeReady()
+#if PLATFORM_ANDROID | PLATFORM_IOS
+void UImtblJSConnector::SetMobileBridgeReady()
 {
         IMTBL_LOG_FUNCSIG
         bIsBridgeReady = true;

--- a/Source/Immutable/Private/Immutable/ImtblJSConnector.h
+++ b/Source/Immutable/Private/Immutable/ImtblJSConnector.h
@@ -51,8 +51,8 @@ public:
     // Bind the func to be called for executing JS. Typically by the BrowserWidget (UE5) or Blui for UE4
     FOnExecuteJsDelegate ExecuteJs;
 
-#if PLATFORM_ANDROID
-    void SetAndroidBridgeReady();
+#if PLATFORM_ANDROID | PLATFORM_IOS
+    void SetMobileBridgeReady();
 #endif
 
 protected:

--- a/Source/Immutable/Public/Immutable/ImmutableSubsystem.h
+++ b/Source/Immutable/Public/Immutable/ImmutableSubsystem.h
@@ -59,7 +59,7 @@ private:
 
     FDelegateHandle WorldTickHandle;
     FDelegateHandle ViewportCreatedHandle;
-#if PLATFORM_ANDROID
+#if PLATFORM_ANDROID | PLATFORM_IOS
     FDelegateHandle EngineInitCompleteHandle;
 #endif
 	


### PR DESCRIPTION
iOS support for Unreal 5.2.

Most changes are the same as Android, except:
* The file URL. It is `"file:///index.html"` instead of `"file://immutable/index.html"`
* RemoveFromParent implementation is the same as Windows and MacOS