### PR TITLE
feat: android pkce flow using custom tabs

### DIFF
--- a/Source/Immutable/Immutable_UPL_Android.xml
+++ b/Source/Immutable/Immutable_UPL_Android.xml
@@ -1,15 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<root>
-    <gameActivityImportAdditions>
-        <insert>
-        </insert>
-    </gameActivityImportAdditions>
+<root xmlns:android="http://schemas.android.com/apk/res/android">
+    <prebuildCopies>
+        <copyDir src="$S(PluginDir)/Private/Immutable/Android/Java" dst="$S(BuildDir)/src/com/immutable/unreal" />
+    </prebuildCopies>
+    <androidManifestUpdates>
+        <addElements tag="queries">
+            <intent>
+                <action android:name="android.support.customtabs.action.CustomTabsService" />
+            </intent>
+        </addElements>
+    </androidManifestUpdates>
     <gameActivityOnCreateAdditions>
         <insert>
             Uri uri = getIntent().getData();
             if (uri != null) {
-            String deeplink = uri.toString();
-            handleDeepLink(uri.toString());
+                String deeplink = uri.toString();
+                handleDeepLink(uri.toString());
             }
         </insert>
     </gameActivityOnCreateAdditions>
@@ -17,8 +23,8 @@
         <insert>
             Uri uri = getIntent().getData();
             if (uri != null) {
-            String deeplink = uri.toString();
-            handleDeepLink(deeplink);
+                String deeplink = uri.toString();
+                handleDeepLink(deeplink);
             }
         </insert>
     </gameActivityOnResumeAdditions>
@@ -27,4 +33,11 @@
             public native void handleDeepLink(String Deeplink);
         </insert>
     </gameActivityClassAdditions>
+    <buildGradleAdditions>
+        <insert>
+            dependencies {
+                implementation 'androidx.browser:browser:1.5.0'
+            }
+        </insert>
+    </buildGradleAdditions>
 </root>

--- a/Source/Immutable/Private/Immutable/Android/ImmutableAndroidJNI.cpp
+++ b/Source/Immutable/Private/Immutable/Android/ImmutableAndroidJNI.cpp
@@ -1,4 +1,5 @@
 #include "ImmutableAndroidJNI.h"
+#include "Immutable/ImmutablePassport.h"
 
 #if PLATFORM_ANDROID
 JNI_METHOD void Java_com_epicgames_unreal_GameActivity_handleDeepLink(JNIEnv* env, jobject obj, jstring jDeeplink)
@@ -10,16 +11,7 @@ JNI_METHOD void Java_com_epicgames_unreal_GameActivity_handleDeepLink(JNIEnv* en
 
     const char *deeplinkCStr = env->GetStringUTFChars(jDeeplink, NULL);
     const FString deeplink = FString(UTF8_TO_TCHAR(deeplinkCStr));
-    DeeplinkCallbackMethod(deeplink);
+    UImmutablePassport::HandleDeepLink(deeplink);
     env->ReleaseStringUTFChars(jDeeplink, deeplinkCStr);
 }
-
-void SetDeeplinkCallbackMethod(void (*CallbackMethod)(FString Deeplink))
-{
-    if (DeeplinkCallbackMethod == NULL)
-    {
-        DeeplinkCallbackMethod = CallbackMethod;
-    }
-}
-
 #endif

--- a/Source/Immutable/Private/Immutable/Android/ImmutableAndroidJNI.h
+++ b/Source/Immutable/Private/Immutable/Android/ImmutableAndroidJNI.h
@@ -5,11 +5,7 @@
 
 extern "C"
 {
-    static void (*DeeplinkCallbackMethod)(FString Deeplink);
-    
     JNI_METHOD void Java_com_epicgames_unreal_GameActivity_handleDeepLink(JNIEnv*, jobject, jstring);
-
-    void SetDeeplinkCallbackMethod(void (*callbackMethod)(FString Deeplink));
 }
 
 #endif

--- a/Source/Immutable/Private/Immutable/Android/Java/ImmutableAndroid.java
+++ b/Source/Immutable/Private/Immutable/Android/Java/ImmutableAndroid.java
@@ -1,0 +1,89 @@
+package com.immutable.unreal;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.graphics.Insets;
+import android.net.Uri;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.view.WindowInsets;
+import android.view.WindowMetrics;
+
+import androidx.annotation.NonNull;
+import androidx.browser.customtabs.CustomTabsCallback;
+import androidx.browser.customtabs.CustomTabsClient;
+import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.browser.customtabs.CustomTabsService;
+import androidx.browser.customtabs.CustomTabsServiceConnection;
+import androidx.browser.customtabs.CustomTabsSession;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.epicgames.unreal.GameActivity;
+
+public class ImmutableAndroid {
+    private static CustomTabsServiceConnection customTabsServiceConnection;
+
+    private static int getCustomTabsHeight(Activity context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowMetrics windowMetrics = context.getWindowManager().getCurrentWindowMetrics();
+            Insets insets = windowMetrics.getWindowInsets()
+                    .getInsetsIgnoringVisibility(WindowInsets.Type.systemBars());
+            return windowMetrics.getBounds().height() - insets.top - insets.bottom;
+        } else {
+            DisplayMetrics displayMetrics = new DisplayMetrics();
+            context.getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+            return displayMetrics.heightPixels;
+        }
+    }
+
+    public static void launchUrl(Activity context, String url) {
+        // Get all apps that can support Custom Tabs Service
+        // i.e. services that can handle ACTION_CUSTOM_TABS_CONNECTION intents
+        PackageManager packageManager = context.getPackageManager();
+        Intent serviceIntent = new Intent();
+        serviceIntent.setAction(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION);
+        List<ResolveInfo> resolvedList = packageManager.queryIntentServices(serviceIntent, 0);
+        List<String> packageNames = new ArrayList<>();
+        for (ResolveInfo info : resolvedList) {
+            if (info.serviceInfo != null) {
+                packageNames.add(info.serviceInfo.packageName);
+            }
+        }
+
+        if (packageNames.size() > 0) {
+            // Get the preferred Custom Tabs package
+            String customTabsPackageName = CustomTabsClient.getPackageName(context, packageNames);
+            if (customTabsPackageName == null) {
+                // Could not get the preferred Custom Tab browser, so launch URL in any browser
+                context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+            } else {
+                customTabsServiceConnection = new CustomTabsServiceConnection() {
+                    @Override
+                    public void onServiceDisconnected(ComponentName name) {
+                        customTabsServiceConnection = null;
+                    }
+
+                    @Override
+                    public void onCustomTabsServiceConnected(@NonNull ComponentName name, @NonNull CustomTabsClient client) {
+                        CustomTabsSession session = client.newSession(new CustomTabsCallback());
+                        // Need to set the session to get custom tabs to show as a bottom sheet
+                        CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder(session)
+                                .setInitialActivityHeightPx(getCustomTabsHeight(context))
+                                .setUrlBarHidingEnabled(true)
+                                .build();
+                        customTabsIntent.launchUrl(context, Uri.parse(url));
+                    }
+                };
+                CustomTabsClient.bindCustomTabsService(context, customTabsPackageName, customTabsServiceConnection);
+            }
+        } else {
+            // Custom Tabs not supported by any browser on the device so launch URL in any browser
+            context.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+        }
+    }
+}

--- a/Source/Immutable/Public/Immutable/ImmutablePassport.h
+++ b/Source/Immutable/Public/Immutable/ImmutablePassport.h
@@ -425,6 +425,7 @@ DECLARE_DELEGATE_OneParam(FImtblPassportHandleDeepLinkDelegate, FString);
 FImtblPassportHandleDeepLinkDelegate OnHandleDeepLink;
 #endif
 
+
 /**
  *
  */
@@ -438,8 +439,10 @@ public:
     DECLARE_MULTICAST_DELEGATE(FOnPassportReadyDelegate);
     
     DECLARE_DELEGATE_OneParam(FImtblPassportResponseDelegate, FImmutablePassportResult);
-
-#if PLATFORM_IOS
+    
+#if PLATFORM_ANDROID
+    static void HandleDeepLink(FString DeepLink);
+#elif PLATFORM_IOS
     static void HandleDeepLink(NSString* sDeepLink);
 #endif
 
@@ -523,5 +526,9 @@ private:
 #if PLATFORM_ANDROID | PLATFORM_IOS
     void OnDeepLinkActivated(FString DeepLink);
     void CompletePKCEFlow(FString Url);
+#endif
+
+#if PLATFORM_ANDROID
+    void CallJniStaticVoidMethod(JNIEnv* Env, const jclass Class, jmethodID Method, ...);
 #endif
 };


### PR DESCRIPTION
* Use Custom Chome Tabs when using PKCE flow for Android. If none of the browsers support Custom Tabs Service, it will fall to the external browser
* Refactored deeplink handling code for Android to use static functions instead of callback