### PR TITLE
feat: add android code to proguard

### DIFF
--- a/Source/Immutable/Immutable_UPL_Android.xml
+++ b/Source/Immutable/Immutable_UPL_Android.xml
@@ -3,6 +3,19 @@
     <prebuildCopies>
         <copyDir src="$S(PluginDir)/Private/Immutable/Android/Java" dst="$S(BuildDir)/src/com/immutable/unreal" />
     </prebuildCopies>
+    <proguardAdditions>
+        <insert>
+            <!-- Disable obfuscation -->
+            -dontwarn com.immutable.unreal
+            -keep class com.immutable.unreal.** { *; }
+            -keep interface com.immutable.unreal.** { *; }
+            -keep public class com.immutable.unreal.ImmutableAndroid.** { public protected *; }
+
+            -dontwarn androidx.**
+            -keep class androidx.** { *; }
+            -keep interface androidx.** { *; }
+        </insert>
+    </proguardAdditions>
     <androidManifestUpdates>
         <addElements tag="queries">
             <intent>

--- a/Source/Immutable/Private/Immutable/Android/Java/ImmutableAndroid.java
+++ b/Source/Immutable/Private/Immutable/Android/Java/ImmutableAndroid.java
@@ -23,8 +23,6 @@ import androidx.browser.customtabs.CustomTabsSession;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.epicgames.unreal.GameActivity;
-
 public class ImmutableAndroid {
     private static CustomTabsServiceConnection customTabsServiceConnection;
 


### PR DESCRIPTION
Proguard now includes `ImmutableAndroid` imports to prevent obfuscation when creating a release build