### PR TITLE
fixes crash when game is packaged as FindPlugin would return nullptr

### DIFF
--- a/Source/Immutable/Private/ImmutableModule.cpp
+++ b/Source/Immutable/Private/ImmutableModule.cpp
@@ -12,7 +12,8 @@ void FImmutableModule::StartupModule() {
   // timing is specified in the .uplugin file per-module
 
 #if USING_BLUI_CEF
-  if (IPluginManager::Get().FindPlugin("WebBrowserWidget") != nullptr && IPluginManager::Get().FindPlugin("WebBrowserWidget")->IsEnabled()) {
+  if (IPluginManager::Get().FindPlugin("WebBrowserWidget") != nullptr && 
+      IPluginManager::Get().FindPlugin("WebBrowserWidget")->IsEnabled()) {
     IMTBL_ERR("Cannot enable both BLUI and WebBrowserWidget plugin at the same "
               "time as it crashes.  In Immutable.uplugin file, "
               "'Plugins->WebBrowserWidget->Enabled' to 'false' and ensure the "

--- a/Source/Immutable/Private/ImmutableModule.cpp
+++ b/Source/Immutable/Private/ImmutableModule.cpp
@@ -12,7 +12,7 @@ void FImmutableModule::StartupModule() {
   // timing is specified in the .uplugin file per-module
 
 #if USING_BLUI_CEF
-  if (IPluginManager::Get().FindPlugin("WebBrowserWidget")->IsEnabled()) {
+  if (IPluginManager::Get().FindPlugin("WebBrowserWidget") != nullptr && IPluginManager::Get().FindPlugin("WebBrowserWidget")->IsEnabled()) {
     IMTBL_ERR("Cannot enable both BLUI and WebBrowserWidget plugin at the same "
               "time as it crashes.  In Immutable.uplugin file, "
               "'Plugins->WebBrowserWidget->Enabled' to 'false' and ensure the "

--- a/Source/Immutable/Private/ImmutableModule.cpp
+++ b/Source/Immutable/Private/ImmutableModule.cpp
@@ -12,7 +12,7 @@ void FImmutableModule::StartupModule() {
   // timing is specified in the .uplugin file per-module
 
 #if USING_BLUI_CEF
-  if (IPluginManager::Get().FindPlugin("WebBrowserWidget") != nullptr && 
+  if (IPluginManager::Get().FindPlugin("WebBrowserWidget") != nullptr &&
       IPluginManager::Get().FindPlugin("WebBrowserWidget")->IsEnabled()) {
     IMTBL_ERR("Cannot enable both BLUI and WebBrowserWidget plugin at the same "
               "time as it crashes.  In Immutable.uplugin file, "


### PR DESCRIPTION
When packaging a game and running the built file (eg. `endlessrun.exe`), it will crash as  `IPluginManager::Get().FindPlugin("WebBrowserWidget")` will be a nullptr.

How to test:
- Package the game and run