### PR TITLE
[DX-2540] fix: android custom tabs dismiss callback nullifing pkce response delegate

### DIFF
--- a/Source/Immutable/Immutable_UPL_Android.xml
+++ b/Source/Immutable/Immutable_UPL_Android.xml
@@ -66,7 +66,7 @@
     <buildGradleAdditions>
         <insert>
             dependencies {
-                implementation 'androidx.browser:browser:1.5.0'
+                implementation 'androidx.browser:browser:1.7.0'
             }
         </insert>
     </buildGradleAdditions>

--- a/Source/Immutable/Private/Immutable/ImmutablePassport.cpp
+++ b/Source/Immutable/Private/Immutable/ImmutablePassport.cpp
@@ -889,23 +889,19 @@ void UImmutablePassport::HandleDeepLink(NSString *sDeepLink) {
 #if PLATFORM_ANDROID
 void UImmutablePassport::HandleOnPKCEDismissed() {
   IMTBL_LOG("Handle On PKCE Dismissed");
-  FFunctionGraphTask::CreateAndDispatchWhenReady(
-      [=]() {
-        OnPKCEDismissed = nullptr;
-        if (!completingPKCE) {
-          // User hasn't entered all required details (e.g. email address) into
-          // Passport yet
-          IMTBL_LOG("PKCE dismissed before completing the flow");
-          if (!PKCEResponseDelegate.ExecuteIfBound(
-                  FImmutablePassportResult{false, "Cancelled"})) {
-            IMTBL_WARN("PKCEResponseDelegate delegate was not called");
-          }
-          PKCEResponseDelegate = nullptr;
-        } else {
-          IMTBL_LOG("PKCE dismissed by user or SDK");
-        }
-      },
-      TStatId(), nullptr, ENamedThreads::GameThread);
+  OnPKCEDismissed = nullptr;
+  if (!completingPKCE) {
+    // User hasn't entered all required details (e.g. email address) into
+    // Passport yet
+    IMTBL_LOG("PKCE dismissed before completing the flow");
+    if (!PKCEResponseDelegate.ExecuteIfBound(
+            FImmutablePassportResult{false, "Cancelled"})) {
+      IMTBL_WARN("PKCEResponseDelegate delegate was not called");
+            }
+    PKCEResponseDelegate = nullptr;
+  } else {
+    IMTBL_LOG("PKCE dismissed by user or SDK");
+  }
 }
 
 void UImmutablePassport::HandleCustomTabsDismissed() {


### PR DESCRIPTION
* On newer Android versions, `onCustomTabsDismissed` is triggered before PKCE deeplink is triggered (by ~100ms). This means `PKCEResponseDelegate` will be set to null before the SDK can use it to notify the consumer of the PKCE result. So added a delay before calling `onCustomTabsDismissed`
* Updated Chrome Custom Tabs version