### PR TITLE
refactor: android custom tabs to not use lambdas

### DIFF
--- a/Source/Immutable/Immutable_UPL_Android.xml
+++ b/Source/Immutable/Immutable_UPL_Android.xml
@@ -18,6 +18,16 @@
             -keep interface androidx.** { *; }
         </insert>
     </proguardAdditions>
+    <buildGradleAdditions>
+        <insert>
+            android {
+                compileOptions {
+                    sourceCompatibility 1.8
+                    targetCompatibility 1.8
+                }
+            }
+        </insert>
+    </buildGradleAdditions>
     <androidManifestUpdates>
         <addElements tag="queries">
             <intent>

--- a/Source/Immutable/Private/Immutable/Android/Java/CustomTabsController.java
+++ b/Source/Immutable/Private/Immutable/Android/Java/CustomTabsController.java
@@ -111,14 +111,17 @@ public class CustomTabsController extends CustomTabsServiceConnection {
             context.startActivity(new Intent(Intent.ACTION_VIEW, uri));
         } else {
             // Running in a different thread to prevent doing too much work on main thread
-            new Thread(() -> {
-                try {
-                    launchCustomTabs(context, uri);
-                } catch (ActivityNotFoundException ex) {
-                    // Failed to launch Custom Tab browser, so launch in browser
-                    context.startActivity(new Intent(Intent.ACTION_VIEW, uri));
-                }
-            }).start();
+            new Thread(new Runnable() {
+               @Override
+               public void run() {
+                   try {
+                       launchCustomTabs(context, uri);
+                   } catch (ActivityNotFoundException ex) {
+                       // Failed to launch Custom Tab browser, so launch in browser
+                       context.startActivity(new Intent(Intent.ACTION_VIEW, uri));
+                   }
+               }
+           }).start();
         }
     }
 


### PR DESCRIPTION
# Summary
* Refactor Android Custom Tabs implementation to not use lambdas
* Specify the Java version