### PR TITLE
[DX-2603] fix: add save game object to store immutable passport pkce connected

### DIFF
--- a/Source/Immutable/Private/Immutable/ImmutableSaveGame.cpp
+++ b/Source/Immutable/Private/Immutable/ImmutableSaveGame.cpp
@@ -1,0 +1,7 @@
+#include "Immutable/ImmutableSaveGame.h"
+
+
+UImmutableSaveGame::UImmutableSaveGame(const FObjectInitializer& ObjectInitializer)
+{
+	bWasConnectedViaPKCEFlow = false;
+}

--- a/Source/Immutable/Private/Immutable/Mac/ImmutableMac.cpp
+++ b/Source/Immutable/Private/Immutable/Mac/ImmutableMac.cpp
@@ -93,6 +93,7 @@ ASWebAuthenticationSession *_authSession;
                   passport->HandleDeepLink(callbackURL.absoluteString);
                 }
               } else {
+              	IMTBL_ERR("callbackURL is empty");
                 return;
               }
             }];

--- a/Source/Immutable/Public/Immutable/ImmutablePassport.h
+++ b/Source/Immutable/Public/Immutable/ImmutablePassport.h
@@ -40,7 +40,7 @@ template <typename UStructType> TOptional<UStructType> JsonObjectToUStruct(const
 }
 
 /**
- *
+ * Immutable sdk Passport object
  */
 UCLASS()
 class IMMUTABLE_API UImmutablePassport : public UObject
@@ -228,8 +228,13 @@ protected:
 
 	void SetStateFlags(uint8 StateIn);
 	void ResetStateFlags(uint8 StateIn);
-	bool IsStateFlagSet(uint8 StateIn) const;
+	bool IsStateFlagsSet(uint8 StateIn) const;
 
+private:
+
+	void SavePassportSettings();
+	void LoadPassportSettings();
+	
 private:
 
 	enum EImmutablePassportStateFlags : uint8
@@ -244,4 +249,6 @@ private:
 	};
 
 	uint8 StateFlags = IPS_NONE;
+	bool bIsPrevConnectedViaPKCEFlow = false;
+	
 };

--- a/Source/Immutable/Public/Immutable/ImmutableSaveGame.h
+++ b/Source/Immutable/Public/Immutable/ImmutableSaveGame.h
@@ -1,0 +1,23 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "GameFramework/SaveGame.h"
+
+#include "ImmutableSaveGame.generated.h"
+
+/**
+ * Immutable sdk save game object
+ */
+UCLASS(BlueprintType, Blueprintable)
+class IMMUTABLE_API UImmutableSaveGame : public USaveGame
+{
+	GENERATED_UCLASS_BODY()
+
+public:
+
+	/** check if player logged in/connected with PKCE flow previously */
+	UPROPERTY(VisibleAnywhere, Category = "Immutable")
+	bool bWasConnectedViaPKCEFlow;
+
+};


### PR DESCRIPTION
# Summary
Resolved an issue with logout using device flow instead of pkce flow for players logged in via pkce flow

<!-- Remove the H2 sections as required -->
## Added 
New save game object to save if player successfully logged in via pkce flow

## Fixed
Fixed incorrect behaviour of logout in case of relogin of pkce flow

