### PR TITLE
[DX-2616] fix: failed login with cached session falls back to login pkce

### DIFF
--- a/Source/Immutable/Private/Immutable/ImmutablePassport.cpp
+++ b/Source/Immutable/Private/Immutable/ImmutablePassport.cpp
@@ -367,8 +367,20 @@ void UImmutablePassport::ReinstateConnection(FImtblJSResponse Response)
 		}
 		else
 		{
-			CallJS(ImmutablePassportAction::INIT_DEVICE_FLOW, TEXT(""), ResponseDelegate.GetValue(),
-				FImtblJSResponseDelegate::CreateUObject(this, &UImmutablePassport::OnInitDeviceFlowResponse));
+#if PLATFORM_ANDROID | PLATFORM_IOS | PLATFORM_MAC
+			if (bIsPrevConnectedViaPKCEFlow)
+			{
+				SetStateFlags(IPS_PKCE);
+				PKCEResponseDelegate = ResponseDelegate.GetValue();
+				CallJS(ImmutablePassportAction::GetPKCEAuthUrl, TEXT(""), PKCEResponseDelegate,
+					FImtblJSResponseDelegate::CreateUObject(this, &UImmutablePassport::OnGetPKCEAuthUrlResponse));
+			}
+			else
+#endif
+			{
+				CallJS(ImmutablePassportAction::INIT_DEVICE_FLOW, TEXT(""), ResponseDelegate.GetValue(),
+					FImtblJSResponseDelegate::CreateUObject(this, &UImmutablePassport::OnInitDeviceFlowResponse));
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Summary
Session that was previously logged in with PKCE flow fall back to PKCE login flow in the event of a relogin failure. The same behaviour is expected for connect with PKCE flow


# Customer Impact
Improves customer experience


# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs: `, `refactor: ` or `test: `.
- [ ] Sample blueprints are updated with new SDK changes
- [ ] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unreal) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unreal))
- [ ] Replied to GitHub issues
