### PR TITLE
[DX-2591] fix: adjusted blui process closure routines

### DIFF
--- a/Source/Immutable/Private/Immutable/ImmutableSubsystem.cpp
+++ b/Source/Immutable/Private/Immutable/ImmutableSubsystem.cpp
@@ -34,11 +34,14 @@ void UImmutableSubsystem::Initialize(FSubsystemCollectionBase &Collection) {
       this, &UImmutableSubsystem::WorldTickStart);
 }
 
-void UImmutableSubsystem::Deinitialize() {
-  IMTBL_LOG_FUNCSIG
-  BrowserWidget = nullptr;
-  ImtblBlui = nullptr;
-  Passport = nullptr;
+void UImmutableSubsystem::Deinitialize()
+{
+	IMTBL_LOG_FUNCSIG
+	BrowserWidget = nullptr;
+	IMTBL_LOG("Stopped BLUI event loop");
+	ImtblBlui->StopBluiEventLoop();
+	ImtblBlui = nullptr;
+	Passport = nullptr;
 #if PLATFORM_ANDROID | PLATFORM_IOS
   UGameViewportClient::OnViewportCreated().Remove(EngineInitCompleteHandle);
 #else

--- a/Source/Immutable/Private/Immutable/ImtblBlui.cpp
+++ b/Source/Immutable/Private/Immutable/ImtblBlui.cpp
@@ -150,3 +150,13 @@ void UImtblBlui::Init() {
   JSConnector->Init(!BluEye->IsBrowserLoading());
 #endif
 }
+
+#if USING_BLUI_CEF
+void UImtblBlui::StopBluiEventLoop()
+{
+	if (UBluEye* BluEye = GetBluEye())
+	{
+		BluEye->SetShouldTickEventLoop(false);
+	}
+}
+#endif

--- a/Source/Immutable/Private/Immutable/ImtblBlui.h
+++ b/Source/Immutable/Private/Immutable/ImtblBlui.h
@@ -28,6 +28,10 @@ public:
   void BeginDestroy() override;
   void Init();
 
+#if USING_BLUI_CEF
+  void StopBluiEventLoop();
+#endif
+
 private:
   UPROPERTY()
   UObject *BluEyePtr = nullptr;

--- a/Source/Immutable/Private/ImmutableModule.cpp
+++ b/Source/Immutable/Private/ImmutableModule.cpp
@@ -4,6 +4,12 @@
 
 #include "Immutable/Misc/ImtblLogging.h"
 #include "Interfaces/IPluginManager.h"
+#if PLATFORM_WINDOWS
+#include "Windows/AllowWindowsPlatformTypes.h"
+#include <windows.h>
+#include <psapi.h>
+#include "Windows/HideWindowsPlatformTypes.h"
+#endif
 
 #define LOCTEXT_NAMESPACE "FImmutableModule"
 
@@ -22,11 +28,61 @@ void FImmutableModule::StartupModule() {
 #endif
 }
 
-void FImmutableModule::ShutdownModule() {
-  // This code will execute after your module is loaded into memory; the exact
-  // timing is specified in the .uplugin file per-module This function may be
-  // called during shutdown to clean up your module.  For modules that support
-  // dynamic reloading, we call this function before unloading the module.
+void FImmutableModule::ShutdownModule()
+{
+#if PLATFORM_WINDOWS && USING_BLUI_CEF
+    DWORD aProcesses[1024], cbNeeded;
+    unsigned int i;
+
+    if (EnumProcesses(aProcesses, sizeof(aProcesses), &cbNeeded))
+    {
+        // Calculate how many process identifiers were returned.
+        DWORD cProcesses = cbNeeded / sizeof(DWORD);
+
+        // Print the name and process identifier for each process.
+        for (i = 0; i < cProcesses; i++)
+        {
+            if (aProcesses[i] != 0)
+            {
+                TCHAR szProcessName[MAX_PATH] = TEXT("<unknown>");
+                // Get a handle to the process.
+                HANDLE hProcess = OpenProcess(PROCESS_ALL_ACCESS, 0, aProcesses[i]);
+                DWORD errCode = GetLastError();
+
+                IMTBL_LOG("PID %d : ERROR %d ", aProcesses[i], errCode);
+                // Get the process name.
+                if (errCode == 0 && hProcess != NULL)
+                {
+                    HMODULE hMod;
+
+                    cbNeeded = 0;
+                    if (EnumProcessModules(hProcess, &hMod, sizeof(hMod), &cbNeeded))
+                    {
+                        if (GetModuleBaseName(hProcess, hMod, szProcessName, sizeof(szProcessName) / sizeof(TCHAR)))
+                        {
+                            if (!_tcscmp(szProcessName, _T("blu_ue4_process.exe")))
+                            {
+                                if (TerminateProcess(hProcess, 0) == 0)
+                                {
+                                    IMTBL_ERR("Faild to shutdown BLUI executable process");
+                                }
+                                else
+                                {
+                                    IMTBL_LOG("BLUI executable process terminated");
+                                }
+                            }
+                        }
+                    }
+                    errCode = GetLastError();
+
+                    // Release the handle to the process.
+                    CloseHandle(hProcess);
+                }
+            }
+        }
+    }
+    
+#endif
 }
 
 #undef LOCTEXT_NAMESPACE


### PR DESCRIPTION
# Summary
We added CEF message loop stop method before BLUI process closure. Also, we added a code that will forcefully close BLUI process if it still hangs. 

# Customer Impact
Improve memory performance on a game/app closure


# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs: `, `refactor: ` or `test: `.
- [ ] Sample blueprints are updated with new SDK changes
- [ ] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unreal) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unreal))
- [ ] Replied to GitHub issues
