### PR TITLE
[DX-2616] fix: added blui macro for ue5 projects

### DIFF
--- a/Source/Immutable/Private/Immutable/ImmutableSubsystem.cpp
+++ b/Source/Immutable/Private/Immutable/ImmutableSubsystem.cpp
@@ -38,8 +38,10 @@ void UImmutableSubsystem::Deinitialize()
 {
 	IMTBL_LOG_FUNCSIG
 	BrowserWidget = nullptr;
+#if USING_BLUI_CEF
 	IMTBL_LOG("Stopped BLUI event loop");
 	ImtblBlui->StopBluiEventLoop();
+#endif
 	ImtblBlui = nullptr;
 	Passport = nullptr;
 #if PLATFORM_ANDROID | PLATFORM_IOS


### PR DESCRIPTION
# Summary
Fixed issue with non-BLUE builds


# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs: `, `refactor: ` or `test: `.
- [ ] Sample blueprints are updated with new SDK changes
- [ ] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unreal) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unreal))
- [ ] Replied to GitHub issues
