### PR TITLE
[DX-2716] feat: ability to skip logging out of auth0 in the browser

### DIFF
--- a/Source/Immutable/Public/Immutable/Actions/ImtblPassportLogoutAsyncAction.h
+++ b/Source/Immutable/Public/Immutable/Actions/ImtblPassportLogoutAsyncAction.h
@@ -18,7 +18,7 @@ class IMMUTABLE_API UImtblPassportLogoutAsyncAction : public UImtblBlueprintAsyn
 
 public:
 	UFUNCTION(BlueprintCallable, meta = (WorldContext = "WorldContextObject", BlueprintInternalUseOnly = "true"), Category = "Immutable")
-	static UImtblPassportLogoutAsyncAction* Logout(UObject* WorldContextObject);
+	static UImtblPassportLogoutAsyncAction* Logout(UObject* WorldContextObject, bool DoHardLogout = true);
 
 	virtual void Activate() override;
 
@@ -27,6 +27,8 @@ private:
 	void OnLogoutResponse(FImmutablePassportResult Result) const;
 
 private:
+	bool bDoHardLogout = true;
+	
 	UPROPERTY(BlueprintAssignable)
 	FPassportLogoutOutPin OnSuccess;
 	UPROPERTY(BlueprintAssignable)

--- a/Source/Immutable/Public/Immutable/ImmutablePassport.h
+++ b/Source/Immutable/Public/Immutable/ImmutablePassport.h
@@ -69,7 +69,7 @@ public:
 	void ConnectPKCE(bool IsConnectImx, const FImtblPassportResponseDelegate& ResponseDelegate);
 #endif
 
-	void Logout(const FImtblPassportResponseDelegate& ResponseDelegate);
+	void Logout(bool DoHardLogout, const FImtblPassportResponseDelegate& ResponseDelegate);
 
 	/**
 	 * Initializes the zkEVM provider.
@@ -239,7 +239,8 @@ private:
 		IPS_IMX = 1 << 2,
 		IPS_PKCE = 1 << 3,
 		IPS_COMPLETING_PKCE = 1 << 4,
-		IPS_INITIALIZED = 1 << 5
+		IPS_INITIALIZED = 1 << 5,
+		IPS_HARDLOGOUT = 1 << 6
 	};
 
 	uint8 StateFlags = IPS_NONE;


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
The SDK's current logout function performs a local logout and also opens the browser to log them out of the browser session. However, some customers might find the browser popup undesirable. To address this issue, a change has been made to allow users to skip logging out of the browser step and only perform a local logout:
* To skip the Auth0 logout and only perform a local logout, set `DoHardLogout` to `false` when calling `Logout` method/blueprint node.
* To perform local and Auth0 logout, set the `DoHardLogout` parameter to `true` when calling the `Logout` method/blueprint node. This is the default.

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->
Developers can now choose not to display the browser pop-up when logging out. However, if they choose this option, users will remain logged into Passport in the browser until the browser session expires.

e.g.
* User logs into Passport with Google Account A
* User logs out without the browser popup (`DoHardLogout` is set to `false`)
* User tries to log into Passport again
* If the Passport session in the browser is:
   * still valid, the user will be automatically logged in as Google Account A
   * no longer valid, the user will go through the full Passport login flow again (choose Google/Email/etc.)

# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [ ] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unreal) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unreal))
