### PR TITLE
[DX-2735] fix: fixed blui browser closure

### DIFF
--- a/Source/Immutable/Private/Immutable/ImmutableSubsystem.cpp
+++ b/Source/Immutable/Private/Immutable/ImmutableSubsystem.cpp
@@ -36,13 +36,16 @@ void UImmutableSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 void UImmutableSubsystem::Deinitialize()
 {
 	IMTBL_LOG_FUNCSIG
+	
 	BrowserWidget = nullptr;
+	
 #if USING_BLUI_CEF
-	IMTBL_LOG("Stopped BLUI event loop");
-	ImtblBlui->StopBluiEventLoop();
-#endif
+	ImtblBlui->ConditionalBeginDestroy();
 	ImtblBlui = nullptr;
+#endif
+	
 	Passport = nullptr;
+	
 #if PLATFORM_ANDROID | PLATFORM_IOS
   UGameViewportClient::OnViewportCreated().Remove(EngineInitCompleteHandle);
 #else

--- a/Source/Immutable/Private/Immutable/ImtblBlui.cpp
+++ b/Source/Immutable/Private/Immutable/ImtblBlui.cpp
@@ -36,13 +36,13 @@ void UImtblBlui::OnLogEvent(const FString& LogText)
 void UImtblBlui::WorldTickStart(UWorld* World, ELevelTick LevelTick, float X)
 {
 #if USING_BLUI_CEF
-  if (GetBluEye()->IsBrowserLoading()) {
-    IMTBL_LOG("Waiting for Browser to load...");
-  } else if (!bLoadedIndexJS) {
-    bLoadedIndexJS = true;
+  if (!GetBluEye()->IsBrowserLoading() && !bLoadedIndexJS) {
     const FSoftObjectPath AssetRef(
-        TEXT("/Script/Immutable.ImtblSDKResource'/Immutable/PackagedResources/"
-             "index.index'"));
+    TEXT("/Script/Immutable.ImtblSDKResource'/Immutable/PackagedResources/"
+         "index.index'"));
+         
+    IMTBL_LOG("Browser loaded");
+    bLoadedIndexJS = true;
     if (UObject *LoadedAsset = AssetRef.TryLoad()) {
       if (const auto Resource = Cast<UImtblSDKResource>(LoadedAsset)) {
         GetBluEye()->ExecuteJS(Resource->Js);
@@ -136,7 +136,7 @@ void UImtblBlui::Init()
       const FString CustomContentMethod(TEXT("X-GET-CUSTOM-CONTENT"));
 
       const auto Request = CefRequest::Create();
-      Request->Set("file://Immutable/index.html", *CustomContentMethod,
+      Request->Set("file:///Immutable/index.html", *CustomContentMethod,
                    PostData, HeaderMap);
 
       GetBluEye()->Browser->GetMainFrame()->LoadRequest(Request);
@@ -144,6 +144,7 @@ void UImtblBlui::Init()
 
       WorldTickHandle = FWorldDelegates::OnWorldTickStart.AddUObject(
           this, &UImtblBlui::WorldTickStart);
+      IMTBL_LOG("Waiting for Browser to load...");
     }
   }
   else

--- a/Source/Immutable/Private/Immutable/ImtblBrowserWidget.cpp
+++ b/Source/Immutable/Private/Immutable/ImtblBrowserWidget.cpp
@@ -91,7 +91,7 @@ void UImtblBrowserWidget::SetBrowserContent()
 			const FString IndexHtml = FString("<!doctype html><html lang='en'><head><meta " "charset='utf-8'><title>GameSDK Bridge</title><script>") + Resource->Js + FString("</script></head><body><h1>Bridge Running</h1></body></html>");
 
 			// IMTBL_LOG("Loaded resource: %s", *Resource->GetName())
-			WebBrowserWidget->LoadString(IndexHtml, TEXT("file://immutable/index.html"));
+			WebBrowserWidget->LoadString(IndexHtml, TEXT("file:///immutable/index.html"));
 			// WebBrowserWidget->LoadURL(FString::Printf(TEXT("%s%s"),
 			// TEXT("file:///"),
 			// *FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectContentDir(),

--- a/Source/Immutable/Private/ImmutableModule.cpp
+++ b/Source/Immutable/Private/ImmutableModule.cpp
@@ -30,61 +30,7 @@ void FImmutableModule::StartupModule()
 }
 
 void FImmutableModule::ShutdownModule()
-{
-#if PLATFORM_WINDOWS && USING_BLUI_CEF
-    DWORD aProcesses[1024], cbNeeded;
-    unsigned int i;
-
-    if (EnumProcesses(aProcesses, sizeof(aProcesses), &cbNeeded))
-    {
-        // Calculate how many process identifiers were returned.
-        DWORD cProcesses = cbNeeded / sizeof(DWORD);
-
-        // Print the name and process identifier for each process.
-        for (i = 0; i < cProcesses; i++)
-        {
-            if (aProcesses[i] != 0)
-            {
-                TCHAR szProcessName[MAX_PATH] = TEXT("<unknown>");
-                // Get a handle to the process.
-                HANDLE hProcess = OpenProcess(PROCESS_ALL_ACCESS, 0, aProcesses[i]);
-                DWORD errCode = GetLastError();
-
-                IMTBL_LOG("PID %d : ERROR %d ", aProcesses[i], errCode);
-                // Get the process name.
-                if (errCode == 0 && hProcess != NULL)
-                {
-                    HMODULE hMod;
-
-                    cbNeeded = 0;
-                    if (EnumProcessModules(hProcess, &hMod, sizeof(hMod), &cbNeeded))
-                    {
-                        if (GetModuleBaseName(hProcess, hMod, szProcessName, sizeof(szProcessName) / sizeof(TCHAR)))
-                        {
-                            if (!_tcscmp(szProcessName, _T("blu_ue4_process.exe")))
-                            {
-                                if (TerminateProcess(hProcess, 0) == 0)
-                                {
-                                    IMTBL_ERR("Faild to shutdown BLUI executable process");
-                                }
-                                else
-                                {
-                                    IMTBL_LOG("BLUI executable process terminated");
-                                }
-                            }
-                        }
-                    }
-                    errCode = GetLastError();
-
-                    // Release the handle to the process.
-                    CloseHandle(hProcess);
-                }
-            }
-        }
-    }
-    
-#endif
-}
+{}
 
 #undef LOCTEXT_NAMESPACE
 


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Fix for CEF browser loading issue primarily addressed on [BLUI plugin](https://github.com/immutable/BLUI) side within [commit](https://github.com/immutable/BLUI/commit/e8d075f653800f27202d8acda969c51de5ba62fc). The issue was in improper browser cleanup/closure procedure. CEF requires to have cache files which can only be used by single process(in this case specifically local storage). Whenever, local storage is locked by closing process, a newly created process is blocked and Immutable plugin forced to wait. 


# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->


<!-- Remove the H2 sections as required -->
## Added 
<!-- Section for new features. -->


## Changed
<!-- Section for changes in existing functionality. -->


## Deprecated
<!-- Section for soon-to-be removed features. -->


## Removed
<!-- Section for now removed features. -->
Forceful blui process closure

## Fixed
<!-- Section for any bug fixes. -->


## Security
<!-- Section in case of vulnerabilities. -->




# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs: `, `refactor: ` or `test: `.
- [ ] Sample blueprints are updated with new SDK changes
- [ ] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unreal) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unreal))
- [ ] Replied to GitHub issues
