### PR TITLE
fix: json parsing issue with empty string

### DIFF
--- a/Source/Immutable/Private/Immutable/ImmutableAnalytics.cpp
+++ b/Source/Immutable/Private/Immutable/ImmutableAnalytics.cpp
@@ -11,7 +11,7 @@ void UImmutableAnalytics::Track(EEventName EventName)
 	
 	FString FullData;
 	
-	FJsonObjectConverter::UStructToJsonObjectString<FEventData>({ "unrealSdk", GetEventName(EventName), "" }, FullData);
+	FJsonObjectConverter::UStructToJsonObjectString<FEventData>({ "unrealSdk", GetEventName(EventName), "{}" }, FullData);
 
 	JSConnector->CallJS(ImmutablePassportAction::TRACK, FullData, FImtblJSResponseDelegate::CreateUObject(this, &UImmutableAnalytics::OnTrackResponse));
 }


### PR DESCRIPTION
# Summary
Resolved a minor issue where an empty string was passed to the analytics instead of a properly formatted empty JSON object.

# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs: `, `refactor: ` or `test: `.
- [ ] Sample blueprints are updated with new SDK changes
- [ ] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unreal) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unreal))
- [ ] Replied to GitHub issues
