### PR TITLE
feat: add silent logout to passport init blueprint

### DIFF
--- a/Source/Immutable/Private/Immutable/Actions/ImtblPassportInitializationAsyncAction.cpp
+++ b/Source/Immutable/Private/Immutable/Actions/ImtblPassportInitializationAsyncAction.cpp
@@ -6,7 +6,7 @@
 #include "Immutable/ImmutableSubsystem.h"
 
 
-UImtblPassportInitializationAsyncAction* UImtblPassportInitializationAsyncAction::InitializePassport(UObject* WorldContextObject, const FString& ClientID, const FString& RedirectUri, const FString& LogoutUri, const FString& Environment)
+UImtblPassportInitializationAsyncAction* UImtblPassportInitializationAsyncAction::InitializePassport(UObject* WorldContextObject, const FString& ClientID, const FString& RedirectUri, const FString& LogoutUri, const FString& Environment, bool IsSilentLogout)
 {
 	UImtblPassportInitializationAsyncAction* PassportInitBlueprintNode = NewObject<UImtblPassportInitializationAsyncAction>();
 
@@ -15,6 +15,7 @@ UImtblPassportInitializationAsyncAction* UImtblPassportInitializationAsyncAction
 	PassportInitBlueprintNode->LogoutUri = LogoutUri;
 	PassportInitBlueprintNode->Environment = Environment;
 	PassportInitBlueprintNode->WorldContextObject = WorldContextObject;
+	PassportInitBlueprintNode->IsSilentLogout = IsSilentLogout;
 
 	return PassportInitBlueprintNode;
 }
@@ -35,7 +36,7 @@ void UImtblPassportInitializationAsyncAction::DoInit(TWeakObjectPtr<UImtblJSConn
 	// Get Passport
 	auto Passport = GetSubsystem()->GetPassport();
 	// Run Initialize
-	Passport->Initialize(FImmutablePassportInitData{ClientId, RedirectUri, LogoutUri, Environment}, UImmutablePassport::FImtblPassportResponseDelegate::CreateUObject(this, &UImtblPassportInitializationAsyncAction::OnInitialized));
+	Passport->Initialize(FImmutablePassportInitData{ClientId, RedirectUri, LogoutUri, Environment, IsSilentLogout}, UImmutablePassport::FImtblPassportResponseDelegate::CreateUObject(this, &UImtblPassportInitializationAsyncAction::OnInitialized));
 }
 
 void UImtblPassportInitializationAsyncAction::OnInitialized(FImmutablePassportResult Result)

--- a/Source/Immutable/Public/Immutable/Actions/ImtblPassportInitializationAsyncAction.h
+++ b/Source/Immutable/Public/Immutable/Actions/ImtblPassportInitializationAsyncAction.h
@@ -20,7 +20,7 @@ class IMMUTABLE_API UImtblPassportInitializationAsyncAction : public UImtblBluep
 
 public:
 	UFUNCTION(BlueprintCallable, meta = (WorldContext = "WorldContextObject", BlueprintInternalUseOnly = "true"), Category = "Immutable")
-	static UImtblPassportInitializationAsyncAction* InitializePassport(UObject* WorldContextObject, const FString& ClientID, const FString& RedirectUri, const FString& LogoutUri, const FString& Environment, bool LogoutMode);
+	static UImtblPassportInitializationAsyncAction* InitializePassport(UObject* WorldContextObject, const FString& ClientID, const FString& RedirectUri, const FString& LogoutUri, const FString& Environment, bool IsSilentLogout);
 
 	virtual void Activate() override;
 

--- a/Source/Immutable/Public/Immutable/Actions/ImtblPassportInitializationAsyncAction.h
+++ b/Source/Immutable/Public/Immutable/Actions/ImtblPassportInitializationAsyncAction.h
@@ -20,7 +20,7 @@ class IMMUTABLE_API UImtblPassportInitializationAsyncAction : public UImtblBluep
 
 public:
 	UFUNCTION(BlueprintCallable, meta = (WorldContext = "WorldContextObject", BlueprintInternalUseOnly = "true"), Category = "Immutable")
-	static UImtblPassportInitializationAsyncAction* InitializePassport(UObject* WorldContextObject, const FString& ClientID, const FString& RedirectUri, const FString& LogoutUri, const FString& Environment);
+	static UImtblPassportInitializationAsyncAction* InitializePassport(UObject* WorldContextObject, const FString& ClientID, const FString& RedirectUri, const FString& LogoutUri, const FString& Environment, bool LogoutMode);
 
 	virtual void Activate() override;
 
@@ -29,6 +29,7 @@ private:
 	FString RedirectUri;
 	FString LogoutUri;
 	FString Environment;
+	bool IsSilentLogout;
 
 	UPROPERTY(BlueprintAssignable)
 	FPassportInitializationOutputPin Initialized;

--- a/Source/Immutable/Public/Immutable/ImmutableDataTypes.h
+++ b/Source/Immutable/Public/Immutable/ImmutableDataTypes.h
@@ -56,7 +56,7 @@ struct IMMUTABLE_API FImmutablePassportInitData
 	FString environment = ImmutablePassportAction::EnvSandbox;
 
 	UPROPERTY()
-	bool IsSilentLogout = false;
+	bool isSilentLogout = false;
 
 	UPROPERTY()
 	FImmutableEngineVersionData engineVersion;

--- a/Source/Immutable/Public/Immutable/ImmutableDataTypes.h
+++ b/Source/Immutable/Public/Immutable/ImmutableDataTypes.h
@@ -56,6 +56,9 @@ struct IMMUTABLE_API FImmutablePassportInitData
 	FString environment = ImmutablePassportAction::EnvSandbox;
 
 	UPROPERTY()
+	bool IsSilentLogout = false;
+
+	UPROPERTY()
 	FImmutableEngineVersionData engineVersion;
 
 	FString ToJsonString() const;


### PR DESCRIPTION
# Summary

[DX-3031](https://immutable.atlassian.net/browse/DX-3197)

Add silent logout option to Passport initialize blueprint node.


# Customer Impact
- Allows developers to select the silent logout method for Passport.


<!-- Remove the H2 sections as required -->
## Added 
- `IsSilentLogout` switch to the Passport `init` blueprint node.


# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs: `, `refactor: ` or `test: `.
- [ ] Sample blueprints are updated with new SDK changes
- [ ] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unreal) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unreal))
- [ ] Replied to GitHub issues


[DX-3031]: https://immutable.atlassian.net/browse/DX-3031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ