### PR TITLE
fix: broken links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 # Documentation
 
-* [Immutable X](https://docs.immutable.com/docs/x/sdks/unreal)
+* [Immutable X](https://docs.immutable.com/sdks/unreal)
 * [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unreal)
 
 ## Plugin Maintainers' Guide
@@ -80,7 +80,7 @@ To get help from other developers, discuss ideas, and stay up-to-date on what's 
 
 You can also join the conversation, connect with other projects, and ask questions in our Immutable X Discourse forum.
 
-[Visit the blog](https//immutable.com/blog)
+[Visit the blog](https://www.immutable.com/blog)
 
 #### Still need help?
 


### PR DESCRIPTION
# Summary

Fix a couple of broken links in the `README.md` file.

Originally raised by:
- https://github.com/immutable/unreal-immutable-sdk/pull/134
- https://github.com/immutable/unreal-immutable-sdk/pull/135

# Customer Impact

No functional changes to the SDK itself. Just `README` updates.

# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs: `, `refactor: ` or `test: `.
- [ ] Sample blueprints are updated with new SDK changes
- [ ] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unreal) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unreal))
- [ ] Replied to GitHub issues
