### PR TITLE
feat: added application configuration utilities

### DIFF
--- a/Source/Immutable/Immutable.Build.cs
+++ b/Source/Immutable/Immutable.Build.cs
@@ -33,6 +33,7 @@ public class Immutable : ModuleRules
                 "Json",
                 "UMG",
                 "Projects", 
+                "DeveloperSettings",
 			}
         );
 

--- a/Source/Immutable/Private/Immutable/ImmutableUtilities.cpp
+++ b/Source/Immutable/Private/Immutable/ImmutableUtilities.cpp
@@ -1,5 +1,6 @@
 #include "Immutable/ImmutableUtilities.h"
 
+#include "Immutable/ImmutablePluginSettings.h"
 #include "Immutable/Misc/ImtblLogging.h"
 #include "Interfaces/IPluginManager.h"
 #include "Misc/FileHelper.h"
@@ -18,4 +19,16 @@ bool FImmutableUtilities::LoadGameBridge(FString& GameBridge)
 	IMTBL_ERR("Failed to load game-bridge file")
 
 	return false;
+}
+
+UApplicationConfig* FImmutableUtilities::GetDefaultApplicationConfig()
+{
+	auto Settings = GetDefault<UImmutablePluginSettings>();
+
+	if (!Settings)
+	{
+		return nullptr;
+	}
+
+	return Settings->DefaultApplicationConfig.GetDefaultObject();
 }

--- a/Source/Immutable/Public/Immutable/ApplicationConfig.h
+++ b/Source/Immutable/Public/Immutable/ApplicationConfig.h
@@ -1,0 +1,162 @@
+﻿#pragma once
+
+#include "ApplicationConfig.generated.h"
+
+/**
+ * @class UApplicationConfig
+ * @brief Configuration settings for Passport and various APIs.
+ * @details This class stores configuration settings such as URLs, chain names, contract addresses, 
+ * client IDs, and environment settings for the zkEVM API, Orderbook API, and Passport.
+ */
+UCLASS(Abstract, Blueprintable, ClassGroup = Immutable)
+class UApplicationConfig : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	/**
+	 * Retrieves URL for the zkEVM API.
+	 *
+	 * @return A constant reference to an FString containing the name of the chain.
+	 */
+	const FString& GetzkEVMAPIURL()
+	{
+		return zkEVMAPIURL;
+	}
+	
+	/**
+	 * Retrieves the name of the chain used to pass to the zkEVM API.
+	 *
+	 * @return A constant reference to an FString containing the name of the chain.
+	 */
+	const FString& GetzkEVMAPIChainName()
+	{
+		return zkEVMAPIChainName;
+	}
+
+	/**
+	 * Retrieves URL for the Orderbook API.
+	 *
+	 * @return A constant reference to an FString containing the name of the chain.
+	 */
+	const FString& GetOrderbookAPIURL()
+	{
+		return OrederbookAPIURL;
+	}
+	
+	/**
+	 * Retrieves the name of the chain used to pass to the Orderbook API.
+	 *
+	 * @return A constant reference to an FString containing the name of the chain.
+	 */
+	const FString& GetOrderbookAPIChainName()
+	{
+		return OrderbookAPIChainName;
+	}
+
+	/**
+	 * @brief Retrieves the cryptocurrency contract address associated with the user's wallet balance.
+	 *
+	 * @return A string representing the contract address.
+	 */
+	const FString& GetTokenBalanceContractAddress()
+	{
+		return TokenBalanceContractAddress;
+	} 
+
+	/**
+	 * Retrieves the list of NFT contracts used in the APIs' queries.
+	 *
+	 * @return A constant reference to an array of strings representing the contracts.
+	 */
+	const TArray<FString>& GetNFTContractAddresses()
+	{
+		return NFTContractAddress;
+	}
+
+	/**
+	 * Retrieves the Client ID used for Passport initialization.
+	 *
+	 * @return A constant reference to an FString containing the Client ID.
+	 */
+	const FString& GetClientID()
+	{
+		return ClientID;	
+	}
+
+	/**
+	 * Retrieves the environment configuration used for Passport initialization.
+	 *
+	 * @return A constant reference to an FString representing the environment.
+	 */
+	const FString& GetEnvironment()
+	{
+		return Environment;
+	}
+
+	/**
+	 * Retrieves the URL where the browser will redirect after successful authentication.
+	 * @note This is only used for Android, iOS, and macOS.
+	 *
+	 * @return A constant reference to an FString containing the redirect URL.
+	 */
+	const FString& GetRedirectURL()
+	{
+		return RedirectURL;
+	}
+
+	/**
+	 * Retrieves the URL used for logging out.
+	 *
+	 * @return A constant reference to an FString containing the logout URL.
+	 */
+	const FString& GetLogoutURL()
+	{
+		return LogoutURL;
+	}
+
+protected:
+	/** The URL for the zkEVM API. */
+	UPROPERTY(EditDefaultsOnly, Category = "zkEVM API")
+	FString zkEVMAPIURL;
+
+	/** The name of the API chain used by the zkEVM API. */
+	UPROPERTY(EditDefaultsOnly, Category = "zkEVM API")
+	FString zkEVMAPIChainName;
+
+	/** The URL for the Orderbook API. */
+	UPROPERTY(EditDefaultsOnly, Category = "Orderbook API")
+	FString OrederbookAPIURL;
+
+	/** The name of the API chain used by Orderbook API. */
+	UPROPERTY(EditDefaultsOnly, Category = "Orderbook API")
+	FString OrderbookAPIChainName;
+	
+	/** The address of the cryptocurrency contract in the blockchain. */
+	UPROPERTY(EditDefaultsOnly, Category = "Contracts")
+	FString TokenBalanceContractAddress;
+
+	/** An array of NFT contract addresses used for searching NFTs in the marketplace or displaying them in the player's inventory. */
+	UPROPERTY(EditDefaultsOnly, Category = "Contracts")
+	TArray<FString> NFTContractAddress;
+
+	/** Passport Client ID. */
+	UPROPERTY(EditDefaultsOnly, Category = "Passport")
+	FString ClientID;
+
+	/** Environment used to initialize passport. Ex. sandbox or production */
+	UPROPERTY(EditDefaultsOnly, Category = "Passport")
+	FString Environment;
+
+	/**
+	 * (Android, iOS, and macOS only)
+	 * The URL where the browser will redirect after successful authentication.
+	 */
+	UPROPERTY(EditDefaultsOnly, Category = "Passport")
+	FString RedirectURL;
+
+	/** The URL where the browser will redirect after logout is complete. */
+	UPROPERTY(EditDefaultsOnly, Category = "Passport")
+	FString LogoutURL;
+	
+};

--- a/Source/Immutable/Public/Immutable/ImmutablePassport.h
+++ b/Source/Immutable/Public/Immutable/ImmutablePassport.h
@@ -81,6 +81,15 @@ public:
 	void Initialize(const FImmutablePassportInitData& InitData, const FImtblPassportResponseDelegate& ResponseDelegate);
 
 	/**
+	 * Initialises passport. This sets up the Passport instance, configures the web browser, and waits for the ready signal.
+	 * @details The functionality is the same with Initilize above except it obtains Passport initilization data from ApplicationConfig asset
+	 * @see UApplicationConfig
+	 *
+	 * @param ResponseDelegate 	Callback delegate.
+	 */
+	void Initialize(const FImtblPassportResponseDelegate& ResponseDelegate);
+
+	/**
 	 * Logs the user into Passport via device code auth and sets up the Immutable X provider.
 	 *
 	 * This will open the user's default browser and take them through Passport login. 

--- a/Source/Immutable/Public/Immutable/ImmutablePluginSettings.h
+++ b/Source/Immutable/Public/Immutable/ImmutablePluginSettings.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Engine/DeveloperSettings.h"
+#include "ApplicationConfig.h"
+
+#include "ImmutablePluginSettings.generated.h"
+
+
+/**
+ * 
+ */
+UCLASS(config = Game, defaultconfig, meta = (DisplayName = "Immutable Plugin Settings"))
+class IMMUTABLE_API UImmutablePluginSettings : public UDeveloperSettings
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "General")
+	TSubclassOf<UApplicationConfig> DefaultApplicationConfig;
+
+};

--- a/Source/Immutable/Public/Immutable/ImmutablePluginSettings.h
+++ b/Source/Immutable/Public/Immutable/ImmutablePluginSettings.h
@@ -7,7 +7,9 @@
 
 
 /**
- * 
+ * ImmutablePluginSettings is a configuration class for the Immutable plugin.
+ * This class contains settings that can be adjusted to control the behavior
+ * of the Immutable plugin within the Unreal Engine environment.
  */
 UCLASS(config = Game, defaultconfig, meta = (DisplayName = "Immutable Plugin Settings"))
 class IMMUTABLE_API UImmutablePluginSettings : public UDeveloperSettings
@@ -15,7 +17,9 @@ class IMMUTABLE_API UImmutablePluginSettings : public UDeveloperSettings
 	GENERATED_BODY()
 
 public:
+	/// The default application configuration class.
+	/// This property holds a reference to a subclass of UApplicationConfig,
+	/// which will be used as the default configuration for the application.
 	UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = "General")
 	TSubclassOf<UApplicationConfig> DefaultApplicationConfig;
-
 };

--- a/Source/Immutable/Public/Immutable/ImmutableUtilities.h
+++ b/Source/Immutable/Public/Immutable/ImmutableUtilities.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "ApplicationConfig.h"
 
 
 /** A wrapper struct around various Immutable namespace utility and support methods. */
@@ -12,4 +13,6 @@ public:
 	 * @return True if the game bridge content was sucessfully retrieved. Otherwise, false.
 	 */
 	static bool LoadGameBridge(FString& GameBridge);
+
+	static UApplicationConfig* GetDefaultApplicationConfig();
 };


### PR DESCRIPTION
# Summary
Added helper class for application configuration.  UApplicationConfig stores configuration settings such as URLs, chain names, contract addresses, client IDs, and environment settings for the zkEVM API, Orderbook API, and Passport. A new settings and utility classes help to retrieve the application config data efficiently. 

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs: `, `refactor: ` or `test: `.
- [ ] Sample blueprints are updated with new SDK changes
- [ ] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unreal) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unreal))
- [x] Replied to GitHub issues
