### PR TITLE
fix: ensure queryparams are set to their correct default values #3552

### DIFF
--- a/Source/ImmutableMarketplace/Public/Bridge/ImmutableBridgeQueryParams.h
+++ b/Source/ImmutableMarketplace/Public/Bridge/ImmutableBridgeQueryParams.h
@@ -11,19 +11,19 @@ struct IMMUTABLEMARKETPLACE_API FImmutableBridgeQueryParams
 	GENERATED_BODY()
 
 public:
-	/** The ID of the source blockchain (default is null). */
+	/** The ID of the source blockchain (default: ""). */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Immutable|Marketplace")
 	FString FromChainID;
 
-	/** The address of the token being moved from (default is null). */
+	/** The address of the token being moved from (default: ""). */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Immutable|Marketplace")
 	FString FromTokenAddress;
 
-	/** The ID of the destination blockchain (default is null). */
+	/** The ID of the destination blockchain (default: ""). */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Immutable|Marketplace")
 	FString ToChainID;
 
-	/** The address of the token being moved to (default is null). */
+	/** The address of the token being moved to (default: ""). */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Immutable|Marketplace")
 	FString ToTokenAddress;
 };

--- a/Source/ImmutableMarketplace/Public/OnRamp/ImmutableOnRampQueryParams.h
+++ b/Source/ImmutableMarketplace/Public/OnRamp/ImmutableOnRampQueryParams.h
@@ -10,19 +10,20 @@ struct IMMUTABLEMARKETPLACE_API FImmutableOnRampQueryParams
 {
 	GENERATED_BODY()
 
+public:
 	/** The cryptocurrency to purchase (default: "IMX"). */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Immutable|Marketplace")
-	FString DefaultCryptoCurrency;
+	FString DefaultCryptoCurrency = TEXT("IMX");
 
 	/** The amount of fiat currency to spend when purchasing cryptocurrency (default: "50"). */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Immutable|Marketplace")
-	FString DefaultFiatAmount;
+	FString DefaultFiatAmount = TEXT("50");
 
 	/** The fiat currency to use (default: "USD"). */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Immutable|Marketplace")
-	FString DefaultFiatCurrency;
+	FString DefaultFiatCurrency = TEXT("USD");
 
 	/** A comma-separated list of available cryptocurrencies for purchase (default: "imx,eth,usdc"). */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Immutable|Marketplace")
-	FString CryptoCurrencyList;
+	FString CryptoCurrencyList = TEXT("imx,eth,usdc");
 };

--- a/Source/ImmutableMarketplace/Public/Swap/ImmutableSwapQueryParams.h
+++ b/Source/ImmutableMarketplace/Public/Swap/ImmutableSwapQueryParams.h
@@ -11,11 +11,11 @@ struct IMMUTABLEMARKETPLACE_API FImmutableSwapQueryParams
 	GENERATED_BODY()
 
 public:
-	/** The address of the token being swapped from (default is null). */
+	/** The address of the token being swapped from (default: ""). */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Immutable|Marketplace")
 	FString FromTokenAddress;
 
-	/** The address of the token being swapped to (default is null). */
+	/** The address of the token being swapped to (default: ""). */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Immutable|Marketplace")
 	FString ToTokenAddress;
 };


### PR DESCRIPTION
# Summary
Ensure queryparams are set to their correct default values


# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [x] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs: `, `refactor: ` or `test: `.
- [ ] Sample blueprints are updated with new SDK changes
- [ ] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unreal) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unreal))
- [ ] Replied to GitHub issues
