### PR TITLE
[DX-3569] ci: update update-version.yml

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -4,9 +4,15 @@ name: "Update engine SDK version in ImmutableDataTypes.h"
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to update to (e.g. 1.20.0)'
+      upgrade_type:
+        type: choice
+        description: Upgrade Type
+        options:
+          - patch
+          - minor
+          # - major
         required: true
+        default: patch
 
 jobs:
   update:
@@ -34,7 +40,24 @@ jobs:
       run: |
         FILE=./Source/Immutable/Public/Immutable/ImmutableDataTypes.h
         VERSION=${{ github.event.inputs.version }}
-        sed -i -E "s/#define ENGINE_SDK_VERSION TEXT\(\"[0-9]+\.[0-9]+\.[0-9]+\"\)/#define ENGINE_SDK_VERSION TEXT(\"$VERSION\")/g" $FILE
+        UPGRADE_TYPE=${{ github.event.inputs.upgrade_type }}
+        
+        # Split version into components
+        IFS='.' read -r major minor patch <<< "$VERSION"
+    
+        # Update version based on upgrade_type
+        if [ "$UPGRADE_TYPE" == "patch" ]; then
+          patch=$((patch + 1))  # Increment patch version
+        elif [ "$UPGRADE_TYPE" == "minor" ]; then
+          minor=$((minor + 1))  # Increment minor version and reset patch
+          patch=0
+        fi
+    
+        # Format the updated version
+        UPDATED_VERSION="$major.$minor.$patch"
+    
+        # Replace the version string in the file
+        sed -i -E "s/#define ENGINE_SDK_VERSION TEXT\(\"[0-9]+\.[0-9]+\.[0-9]+\"\)/#define ENGINE_SDK_VERSION TEXT(\"$UPDATED_VERSION\")/g" $FILE
 
     - uses: gr2m/create-or-update-pull-request-action@v1
       env:

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -72,6 +72,7 @@ jobs:
         sed -i -E "s/#define ENGINE_SDK_VERSION TEXT\(\"[0-9]+\.[0-9]+\.[0-9]+(\.[a-zA-Z]+)?\"\)/#define ENGINE_SDK_VERSION TEXT(\"$UPDATED_VERSION\")/g" $FILE
     
         echo "Updated version: $UPDATED_VERSION"
+        echo "version=$UPDATED_VERSION" >> "$GITHUB_OUTPUT"
 
     - uses: gr2m/create-or-update-pull-request-action@v1
       env:
@@ -79,6 +80,6 @@ jobs:
       with:
         title: "chore: update version"
         body: "Update version in ImmutableDataTypes.h"
-        branch: "chore/update-version-${{ github.event.inputs.version }}"
+        branch: "chore/update-version-${{ steps.replace_engine_sdk_version.outputs.version }}"
         commit-message: "chore: update version"
         labels: release

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -39,25 +39,39 @@ jobs:
       id: replace_engine_sdk_version
       run: |
         FILE=./Source/Immutable/Public/Immutable/ImmutableDataTypes.h
-        VERSION=${{ github.event.inputs.version }}
         UPGRADE_TYPE=${{ github.event.inputs.upgrade_type }}
-        
-        # Split version into components
+    
+        RAW_VERSION=$(grep -oP '#define ENGINE_SDK_VERSION TEXT\("\K[0-9]+\.[0-9]+\.[0-9]+(\.[a-zA-Z]+)?' $FILE)
+    
+        VERSION=$(echo "$RAW_VERSION" | grep -oP '^[0-9]+\.[0-9]+\.[0-9]+')
+    
         IFS='.' read -r major minor patch <<< "$VERSION"
     
-        # Update version based on upgrade_type
-        if [ "$UPGRADE_TYPE" == "patch" ]; then
-          patch=$((patch + 1))  # Increment patch version
-        elif [ "$UPGRADE_TYPE" == "minor" ]; then
-          minor=$((minor + 1))  # Increment minor version and reset patch
-          patch=0
+        # If the version had an alpha suffix, adjust the version bump behavior
+        if [[ "$RAW_VERSION" == *".alpha" ]]; then
+          if [ "$UPGRADE_TYPE" == "patch" ]; then
+            # Remove alpha suffix, keep the same version
+            UPDATED_VERSION="$major.$minor.$patch"
+          elif [ "$UPGRADE_TYPE" == "minor" ]; then
+            # E.g. skip 1.3.0, go directly to 1.4.0
+            minor=$((minor + 1))
+            patch=0
+            UPDATED_VERSION="$major.$minor.$patch"
+          fi
+        else
+          # Increment patch or minor
+          if [ "$UPGRADE_TYPE" == "patch" ]; then
+            patch=$((patch + 1))
+          elif [ "$UPGRADE_TYPE" == "minor" ]; then
+            minor=$((minor + 1))
+            patch=0
+          fi
+          UPDATED_VERSION="$major.$minor.$patch"
         fi
     
-        # Format the updated version
-        UPDATED_VERSION="$major.$minor.$patch"
+        sed -i -E "s/#define ENGINE_SDK_VERSION TEXT\(\"[0-9]+\.[0-9]+\.[0-9]+(\.[a-zA-Z]+)?\"\)/#define ENGINE_SDK_VERSION TEXT(\"$UPDATED_VERSION\")/g" $FILE
     
-        # Replace the version string in the file
-        sed -i -E "s/#define ENGINE_SDK_VERSION TEXT\(\"[0-9]+\.[0-9]+\.[0-9]+\"\)/#define ENGINE_SDK_VERSION TEXT(\"$UPDATED_VERSION\")/g" $FILE
+        echo "Updated version: $UPDATED_VERSION"
 
     - uses: gr2m/create-or-update-pull-request-action@v1
       env:


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Update the "update version" GitHub Action workflow to use minor and patch inputs instead of requiring a manually entered version string.

- Handles alpha versions correctly:
  - Patch update: Converts `1.3.0.alpha` → `1.3.0` (removes `.alpha`).
  - Minor update: Converts `1.3.0.alpha` → `1.4.0` (skips `1.3.0`).