### PR TITLE
[DX-3571] ci: update version alpha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@
 name: 'Create Release'
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ["Tag Release"]
     types:
@@ -9,12 +10,17 @@ on:
 
 jobs:
   release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-          
+
+      - name: Get the latest tag
+        run: |
+          git fetch --tags
+          LATEST_TAG="$(git describe --tags "$(git rev-list --tags --max-count=1)")"
+          echo "LATEST_TAG=${LATEST_TAG}" >> "$GITHUB_ENV"
+
       - name: Extract TS SDK version from index.js
         id: extract_ts_sdk_version
         run: |
@@ -28,7 +34,7 @@ jobs:
           version=$(echo "$version" | tr -d '\r\n')
 
           echo "VERSION=${version}" >> "$GITHUB_ENV"
-          
+
       - name: Build Changelog
         id: github_release
         uses: mikepenz/release-changelog-builder-action@v3
@@ -52,9 +58,8 @@ jobs:
       - name: Create Release
         uses: mikepenz/action-gh-release@v0.2.0-a03
         with:
+            tag_name: ${{ env.LATEST_TAG }}
             body: |
               ${{steps.github_release.outputs.changelog}}
 
               Game bridge built from Immutable Typescript SDK version ${{ env.VERSION }}
-            
-      

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -13,6 +13,11 @@ on:
           # - major
         required: true
         default: patch
+      mark_as_alpha:
+        type: boolean
+        description: Mark as alpha release
+        required: false
+        default: false
 
 jobs:
   update:
@@ -40,26 +45,23 @@ jobs:
       run: |
         FILE=./Source/Immutable/Public/Immutable/ImmutableDataTypes.h
         UPGRADE_TYPE=${{ github.event.inputs.upgrade_type }}
+        MARK_AS_ALPHA=${{ github.event.inputs.mark_as_alpha }}
     
         RAW_VERSION=$(grep -oP '#define ENGINE_SDK_VERSION TEXT\("\K[0-9]+\.[0-9]+\.[0-9]+(\.[a-zA-Z]+)?' $FILE)
-    
         VERSION=$(echo "$RAW_VERSION" | grep -oP '^[0-9]+\.[0-9]+\.[0-9]+')
+        HAS_ALPHA=$(echo "$RAW_VERSION" | grep -q "\.alpha" && echo "true" || echo "false")
     
         IFS='.' read -r major minor patch <<< "$VERSION"
     
-        # If the version had an alpha suffix, adjust the version bump behavior
-        if [[ "$RAW_VERSION" == *".alpha" ]]; then
+        if [[ "$HAS_ALPHA" == "true" ]]; then
           if [ "$UPGRADE_TYPE" == "patch" ]; then
-            # Remove alpha suffix, keep the same version
             UPDATED_VERSION="$major.$minor.$patch"
           elif [ "$UPGRADE_TYPE" == "minor" ]; then
-            # E.g. skip 1.3.0, go directly to 1.4.0
             minor=$((minor + 1))
             patch=0
             UPDATED_VERSION="$major.$minor.$patch"
           fi
         else
-          # Increment patch or minor
           if [ "$UPGRADE_TYPE" == "patch" ]; then
             patch=$((patch + 1))
           elif [ "$UPGRADE_TYPE" == "minor" ]; then
@@ -67,6 +69,10 @@ jobs:
             patch=0
           fi
           UPDATED_VERSION="$major.$minor.$patch"
+        fi
+    
+        if [[ "$MARK_AS_ALPHA" == "true" && "$HAS_ALPHA" == "false" ]]; then
+          UPDATED_VERSION="$UPDATED_VERSION.alpha"
         fi
     
         sed -i -E "s/#define ENGINE_SDK_VERSION TEXT\(\"[0-9]+\.[0-9]+\.[0-9]+(\.[a-zA-Z]+)?\"\)/#define ENGINE_SDK_VERSION TEXT(\"$UPDATED_VERSION\")/g" $FILE


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
This PR updates the GitHub Actions workflow to include a new "Mark as alpha release" checkbox. When selected, the updated version will have the `.alpha` suffix unless it already exists.

- Added a `mark_as_alpha` input (boolean checkbox).  
- Adjusted version bumping logic:  
  - If **not marked as alpha**, `.alpha` is removed if present.  
  - If **marked as alpha**, `.alpha` is added if not already present.  
- Ensured correct version increments for both **patch** and **minor** updates. 

Example:

| Current Version | Upgrade Type | Mark as Alpha | New Version |  
|----------------|-------------|---------------|-------------|  
| 1.3.0.alpha   | Patch       | No            | 1.3.0       |  
| 1.3.0.alpha   | Minor       | No            | 1.4.0       |  
| 1.3.0         | Patch       | No            | 1.3.1       |  
| 1.3.0         | Minor       | No            | 1.4.0       |  
| 1.3.0.alpha   | Patch       | Yes           | 1.3.1.alpha |  
| 1.3.0.alpha   | Minor       | Yes           | 1.4.0.alpha |  
| 1.3.0         | Patch       | Yes           | 1.3.1.alpha |  
| 1.3.0         | Minor       | Yes           | 1.4.0.alpha |  