### PR TITLE
[DX-3616] ci: add v prefix to tag name when creating a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Create Release
         uses: mikepenz/action-gh-release@v0.2.0-a03
         with:
-            tag_name: ${{ env.VERSION }}
+            tag_name: v${{ env.VERSION }}
             body: |
               ${{steps.github_release.outputs.changelog}}
 


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->
Updated the release workflow to use tags with the prefix 'v' when creating a release.