### PR TITLE
[ID-3775] chore: Migrate tests that use Device Code Auth to PKCE

### DIFF
--- a/Source/Immutable/Private/Immutable/Mac/ImmutableMac.cpp
+++ b/Source/Immutable/Private/Immutable/Mac/ImmutableMac.cpp
@@ -1,7 +1,9 @@
 #include "ImmutableMac.h"
+
+#include "Engine/GameEngine.h"
+
 #include "Immutable/ImmutablePassport.h"
 #include "Immutable/ImmutableSubsystem.h"
-#include "Engine/GameEngine.h"
 
 #if WITH_EDITOR
 #include "Editor.h"
@@ -67,6 +69,13 @@ ASWebAuthenticationSession *_authSession;
 }
 
 - (void)launchUrl:(const char *)url forRedirectUri:(const char *)redirectUri {
+  // For automation, use the browser-based method
+  if (GIsAutomationTesting) {
+    NSLog(@"Using automation mode for authentication (GIsAutomationTesting is true)");
+    [self launchUrlInBrowser:url];
+    return;
+  }
+
   if (@available(macOS 10.15, *)) {
     NSURL *URL =
         [NSURL URLWithString:[[NSString alloc] initWithUTF8String:url]];
@@ -102,6 +111,20 @@ ASWebAuthenticationSession *_authSession;
     _authSession.presentationContextProvider = self;
     [_authSession start];
   }
+}
+
+- (void)launchUrlInBrowser:(const char *)url {
+    // Add redundant check to ensure this only runs for automated testing
+    if (!GIsAutomationTesting) {
+        return;
+    }
+
+    // Create URL object
+    NSURL *URL = [NSURL URLWithString:[[NSString alloc] initWithUTF8String:url]];
+    
+    // Open URL in default browser
+    [[NSWorkspace sharedWorkspace] openURL:URL];
+    NSLog(@"Opened URL in browser for automation: %@", URL);
 }
 
 - (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:

--- a/Source/Immutable/Private/Immutable/Mac/ImmutableMac.h
+++ b/Source/Immutable/Private/Immutable/Mac/ImmutableMac.h
@@ -7,4 +7,5 @@
     : NSObject <ASWebAuthenticationPresentationContextProviding>
 + (ImmutableMac *)instance;
 - (void)launchUrl:(const char *)url forRedirectUri:(const char *)redirectUri;
+- (void)launchUrlInBrowser:(const char *)url;
 @end


### PR DESCRIPTION
# Summary
<!--- A short summary of what this PR is doing. -->

* Fix passport is nil during automated tests
* Add workaround to `ASWebAuthenticationSession` confirm dialog for automated tests. For automated test, pkce tests will use `launchUrlInBrowser` instead of `ASWebAuthenticationSession` as the confirm dialog can not be automated or skipped

Jira Ticket: [ID-3775](https://immutable.atlassian.net/browse/ID-3775)

# Customer Impact
<!-- How this change will impact customers. Make sure to highlight any breaking changes. -->


<!-- Remove the H2 sections as required -->
## Added 
<!-- Section for new features. -->


## Changed
<!-- Section for changes in existing functionality. -->


## Deprecated
<!-- Section for soon-to-be removed features. -->


## Removed
<!-- Section for now removed features. -->


## Fixed
<!-- Section for any bug fixes. -->


## Security
<!-- Section in case of vulnerabilities. -->




# Things worth calling out
<!--- Give useful tips/gotchas/trade-offs made to the reviewers. -->


# Other things to consider:
<!-- List of things to check before/after submitting the PR -->

- [ ] Prefix your PR title with `feat: `, `fix: `, `chore: `, `docs: `, `refactor: ` or `test: `.
- [ ] Sample blueprints are updated with new SDK changes
- [ ] Updated public documentation with new SDK changes ([Immutable X](https://docs.immutable.com/docs/x/sdks/unreal) and [Immutable zkEVM](https://docs.immutable.com/docs/zkEVM/sdks/unreal))
- [ ] Replied to GitHub issues


[ID-3775]: https://immutable.atlassian.net/browse/ID-3775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ