### PR TITLE
chore: bump version to 1.11.3 to trigger release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
 # Changelog
 
 Please see https://github.com/immutable/unreal-immutable-sdk/releases
-
-<!-- dummy change to verify the release workflow trigger; safe to close/discard -->
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
 # Changelog
 
 Please see https://github.com/immutable/unreal-immutable-sdk/releases
+
+<!-- dummy change to verify the release workflow trigger; safe to close/discard -->
+

--- a/Source/Immutable/Public/Immutable/ImmutableDataTypes.h
+++ b/Source/Immutable/Public/Immutable/ImmutableDataTypes.h
@@ -17,7 +17,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FImmutableDeepLinkDynamicMulticastDe
 
 // This is the version of the Unreal Immutable SDK that is being used. This is not the version of the engine.
 // This hardcoded value will be updated by a workflow during the release process.
-#define ENGINE_SDK_VERSION TEXT("1.11.2")
+#define ENGINE_SDK_VERSION TEXT("1.11.3")
 
 /**
  * Enum representing marketing consent status for authentication


### PR DESCRIPTION
Bumps ENGINE_SDK_VERSION 1.11.2 -> 1.11.3 to exercise the `Tag Release` / `Create Release` workflows end-to-end (tag v1.11.2 already exists, so a version bump is needed for Tag Release to succeed). Has the `release` label applied.