### PR TITLE
chore: update CODEOWNERS - replace passport team with sdk-integrations and blockchain teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @immutable/passport
+* @immutable/ped-stream-sdk-integrations-list @immutable/ped-engineering-blockchain-list


### PR DESCRIPTION
Replicates #242 (authored by @JCSanPedro) under a different author so it can receive an independent approval.

Replaces `@immutable/passport` (appears to no longer have usable access to this repo, blocking required code-owner review on other PRs) with two owning teams:
- `@immutable/ped-stream-sdk-integrations-list`
- `@immutable/ped-engineering-blockchain-list`

These are the team slugs used for equivalent ownership in other Immutable repos (e.g. platform-services CODEOWNERS).

**Note:** Couldn't verify via API (needs `admin:org` scope) whether these two teams already have write access to this repo. If they don't, GitHub still won't be able to request their review as code owners even after this merges — someone with repo/org admin should confirm or grant access.

**Heads up on merging:** since CODEOWNERS on `main` still points at `@immutable/passport` until this merges, this PR may hit the same "non-existent/inaccessible team" approval block. It may need an admin override or branch-protection adjustment to land.