### PR TITLE
chore: bump version to 1.11.4 to trigger release workflow

### DIFF
--- a/Source/Immutable/Public/Immutable/ImmutableDataTypes.h
+++ b/Source/Immutable/Public/Immutable/ImmutableDataTypes.h
@@ -17,7 +17,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FImmutableDeepLinkDynamicMulticastDe
 
 // This is the version of the Unreal Immutable SDK that is being used. This is not the version of the engine.
 // This hardcoded value will be updated by a workflow during the release process.
-#define ENGINE_SDK_VERSION TEXT("1.11.3")
+#define ENGINE_SDK_VERSION TEXT("1.11.4")
 
 /**
  * Enum representing marketing consent status for authentication


### PR DESCRIPTION
Follow-up noop release-workflow test (after #244 merged and bumped to 1.11.3).

Bumps `ENGINE_SDK_VERSION` 1.11.3 -> 1.11.4 to exercise the `Tag Release` / `Create Release` workflows end-to-end.

**@JCSanPedro** — please add the `release` label manually after approving; my account only has read access and can't apply it.