### PR TITLE
ci: grant contents:write to release workflows so tag/release creation works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
   release:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,6 +9,8 @@ jobs:
   create-tag:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem
The `Tag Release` (`tag.yml`) and `Create Release` (`release.yml`) workflows silently stopped producing releases. The most recent `Tag Release` run failed at the tag-creation step:

```
negz/create-tag@v1  (v1.11.4)
##[error]Resource not accessible by integration
```

The runner reported the job's `GITHUB_TOKEN` as **read-only** (`Contents: read`), so it can't push a tag.

## Root cause
Neither workflow declared a `permissions:` block, so both inherited the repo/org **default** workflow-token scope. That default used to be *read/write* — `Tag Release` succeeded for **v1.11.1** (2025-09-30) and **v1.11.2** (2025-12-22) — but has since been hardened to **read-only**. No workflow code changed; the environment default did, which silently broke tag/release creation.

## Fix
Explicitly scope the two jobs to `contents: write` so they no longer depend on the org/repo default:
- `tag.yml` → `create-tag` job (needs to push the tag)
- `release.yml` → `release` job (`action-gh-release` writes the release/tag)

This is the minimal, self-contained fix and is unaffected if an admin flips the org default again.

## Note on merging
This PR needs the `release` label added by a maintainer for the end-to-end `Tag Release` flow — though this change to the workflow files themselves takes effect on merge regardless.