### PR TITLE
chore: bump version to 1.11.5 to trigger release workflow

### DIFF
--- a/Source/Immutable/Public/Immutable/ImmutableDataTypes.h
+++ b/Source/Immutable/Public/Immutable/ImmutableDataTypes.h
@@ -17,7 +17,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FImmutableDeepLinkDynamicMulticastDe
 
 // This is the version of the Unreal Immutable SDK that is being used. This is not the version of the engine.
 // This hardcoded value will be updated by a workflow during the release process.
-#define ENGINE_SDK_VERSION TEXT("1.11.4")
+#define ENGINE_SDK_VERSION TEXT("1.11.5")
 
 /**
  * Enum representing marketing consent status for authentication


### PR DESCRIPTION
Bumps `ENGINE_SDK_VERSION` 1.11.4 -> 1.11.5 to exercise the `Tag Release` / `Create Release` pipeline end-to-end, now that #246 granted the workflows `contents: write`.

**@JCSanPedro** — please add the `release` label before/at merge; my account only has read access and can't apply it. With the label + the permissions fix on main, Tag Release should now create `v1.11.5` and Create Release should publish it.